### PR TITLE
ci: add reusable secrets scan workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    name: Secrets scan
+    uses: fwd-ford/.github/.github/workflows/secrets-scan.yml@main

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Gitleaks config for forward-mobile.
+# Configuracao do gitleaks para o forward-mobile.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Expo public runtime config — Supabase anon key is public by design (RLS protects data)"
+paths = [
+    '''^app\.json$''',
+]


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that calls the org-shared `secrets-scan.yml` (gitleaks v8.18.4) from `fwd-ford/.github` on every push and PR.

## Why

`forward-mobile` had no CI workflow at all. With the repos now public, any future secret accidentally committed would not be detected here. This brings parity with `forward-api-java`, which already uses the same reusable workflow.

## Test plan

- [ ] Workflow runs on push and shows green
- [ ] Workflow runs on PR and reports any leaks via PR comments