### PR TITLE
feat: theme system with light/dark toggle and UI primitives

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,11 @@
 import { Tabs } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { colors } from "@/lib/theme";
+
+import { useTheme } from "@/context/ThemeContext";
 
 export default function TabsLayout() {
   const { t } = useTranslation();
+  const { colors } = useTheme();
   return (
     <Tabs
       screenOptions={{

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,14 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FlatList, RefreshControl, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { useTheme } from "@/context/ThemeContext";
 import { api, ApiError, type Lead } from "@/lib/api";
 import { getAccessToken } from "@/lib/session";
-import { colors, spacing, typography } from "@/lib/theme";
+import { spacing, typography, type ThemeColors } from "@/lib/theme";
 
 export default function HomeScreen() {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
   const [leads, setLeads] = useState<Lead[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -33,27 +37,44 @@ export default function HomeScreen() {
 
   return (
     <FlatList
+      style={styles.container}
       data={leads}
       keyExtractor={(l) => l.id}
       contentContainerStyle={styles.list}
-      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={load} tintColor={colors.text} />}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={load}
+          tintColor={colors.text}
+        />
+      }
       ListHeaderComponent={
         <View style={styles.header}>
           <Text style={styles.title}>{t("home.todays_leads")}</Text>
           {error ? <Text style={styles.error}>{error}</Text> : null}
         </View>
       }
-      ListEmptyComponent={!refreshing ? <Text style={styles.empty}>{t("home.empty")}</Text> : null}
+      ListEmptyComponent={
+        !refreshing ? (
+          <EmptyState
+            icon="briefcase-outline"
+            title={t("home.empty_title")}
+            description={t("home.empty_description")}
+          />
+        ) : null
+      }
       renderItem={({ item }) => <LeadCard lead={item} />}
       ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
     />
   );
 }
 
-const styles = StyleSheet.create({
-  list: { padding: spacing.lg, paddingBottom: spacing.xxl },
-  header: { marginBottom: spacing.lg, gap: spacing.sm },
-  title: { ...typography.h1, color: colors.text },
-  empty: { ...typography.body, color: colors.textMuted, textAlign: "center", marginTop: spacing.xxl },
-  error: { ...typography.body, color: colors.danger },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: { backgroundColor: c.bg },
+    list: { padding: spacing.lg, paddingBottom: spacing["3xl"] },
+    header: { marginBottom: spacing.lg, gap: spacing.sm },
+    title: { ...typography.h1, color: c.text },
+    error: { ...typography.body, color: c.error },
+  });
+}

--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -1,15 +1,19 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FlatList, StyleSheet, Text, View } from "react-native";
 import { Link } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { useTheme } from "@/context/ThemeContext";
 import { api, ApiError, type Lead } from "@/lib/api";
 import { getAccessToken } from "@/lib/session";
-import { colors, spacing, typography } from "@/lib/theme";
+import { spacing, typography, type ThemeColors } from "@/lib/theme";
 
 export default function LeadsScreen() {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
   const [leads, setLeads] = useState<Lead[]>([]);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,10 +30,20 @@ export default function LeadsScreen() {
 
   return (
     <FlatList
+      style={styles.container}
       data={leads}
       keyExtractor={(l) => l.id}
       contentContainerStyle={styles.list}
       ListHeaderComponent={error ? <Text style={styles.error}>{error}</Text> : null}
+      ListEmptyComponent={
+        !error ? (
+          <EmptyState
+            icon="briefcase-outline"
+            title={t("home.empty_title")}
+            description={t("home.empty_description")}
+          />
+        ) : null
+      }
       renderItem={({ item }) => (
         <Link href={{ pathname: "/lead/[id]", params: { id: item.id } }} asChild>
           <View>
@@ -42,7 +56,10 @@ export default function LeadsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  list: { padding: spacing.lg, paddingBottom: spacing.xxl },
-  error: { ...typography.body, color: colors.danger, marginBottom: spacing.md },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: { backgroundColor: c.bg },
+    list: { padding: spacing.lg, paddingBottom: spacing["3xl"] },
+    error: { ...typography.body, color: c.error, marginBottom: spacing.md },
+  });
+}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,28 +1,234 @@
-import { StyleSheet, Text, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Switch, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { router } from "expo-router";
 
 import { Button } from "@/components/ui/Button";
+import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import { ProfileAvatar } from "@/components/ui/ProfileAvatar";
+import { useTheme } from "@/context/ThemeContext";
+import { haptic } from "@/lib/haptics";
 import { signOut } from "@/lib/auth";
-import { colors, spacing, typography } from "@/lib/theme";
+import { supabase } from "@/lib/supabase";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+
+type SessionUser = {
+  email: string | null;
+  fullName: string | null;
+};
 
 export default function ProfileScreen() {
   const { t } = useTranslation();
+  const { colors, mode, toggleTheme, isOverridden, resetToSystem } = useTheme();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const [user, setUser] = useState<SessionUser | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      const u = data.user;
+      setUser({
+        email: u?.email ?? null,
+        fullName: (u?.user_metadata?.full_name as string | undefined) ?? null,
+      });
+    });
+  }, []);
 
   async function onSignOut() {
+    haptic.medium();
     await signOut();
     router.replace("/login");
   }
 
+  function onToggleTheme() {
+    haptic.selection();
+    toggleTheme();
+  }
+
+  function onResetToSystem() {
+    haptic.light();
+    resetToSystem();
+  }
+
+  if (!user) {
+    return <LoadingScreen label={t("loading.profile")} />;
+  }
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{t("app.name")}</Text>
-      <Button label={t("profile.sign_out")} variant="secondary" onPress={onSignOut} />
-    </View>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={[
+        styles.scrollContent,
+        { paddingTop: insets.top + spacing.lg, paddingBottom: insets.bottom + spacing["4xl"] },
+      ]}
+      showsVerticalScrollIndicator={false}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>{t("tabs.profile")}</Text>
+      </View>
+
+      <View style={styles.userCard}>
+        <ProfileAvatar
+          source={user.fullName ?? user.email ?? "?"}
+          size={56}
+        />
+        <View style={styles.userInfo}>
+          <Text style={styles.userName} numberOfLines={1}>
+            {user.fullName ?? t("profile.unnamed")}
+          </Text>
+          <Text style={styles.userEmail} numberOfLines={1}>
+            {user.email ?? "—"}
+          </Text>
+        </View>
+      </View>
+
+      <Text style={styles.sectionTitle}>{t("profile.appearance")}</Text>
+      <View style={styles.themeCard}>
+        <View style={styles.themeInfo}>
+          <View style={styles.themeIconWrap}>
+            <Ionicons
+              name={mode === "dark" ? "moon" : "sunny"}
+              size={18}
+              color={colors.primary}
+            />
+          </View>
+          <View style={styles.themeTextos}>
+            <Text style={styles.themeLabel}>
+              {mode === "dark" ? t("profile.dark_mode") : t("profile.light_mode")}
+            </Text>
+            <Text style={styles.themeSub}>
+              {isOverridden ? t("profile.theme_manual") : t("profile.theme_auto")}
+            </Text>
+          </View>
+        </View>
+        <Switch
+          value={mode === "dark"}
+          onValueChange={onToggleTheme}
+          trackColor={{ false: colors.borderStrong, true: colors.primary }}
+          thumbColor="#FFFFFF"
+          ios_backgroundColor={colors.borderStrong}
+        />
+      </View>
+
+      {isOverridden ? (
+        <Pressable
+          onPress={onResetToSystem}
+          style={({ pressed }) => [styles.linkRow, pressed && styles.pressedSoft]}
+          accessibilityRole="button"
+          accessibilityLabel={t("profile.follow_system")}
+        >
+          <Text style={styles.linkText}>{t("profile.follow_system")}</Text>
+        </Pressable>
+      ) : null}
+
+      <Text style={styles.sectionTitle}>{t("profile.account")}</Text>
+      <View style={styles.actionsCard}>
+        <Button label={t("profile.sign_out")} variant="secondary" onPress={onSignOut} />
+      </View>
+    </ScrollView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, padding: spacing.xl, gap: spacing.xl, backgroundColor: colors.bg },
-  title: { ...typography.h1, color: colors.text },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: c.bg },
+    scrollContent: {
+      paddingHorizontal: 0,
+    },
+    header: {
+      paddingHorizontal: spacing.xl,
+      marginBottom: spacing.lg,
+    },
+    title: {
+      ...typography.h1,
+      color: c.text,
+    },
+    userCard: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.lg,
+      marginHorizontal: spacing.xl,
+      marginBottom: spacing.xl,
+      backgroundColor: c.surface,
+      borderRadius: radius.xl,
+      padding: spacing.lg,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    userInfo: { flex: 1 },
+    userName: {
+      ...typography.h3,
+      color: c.text,
+    },
+    userEmail: {
+      ...typography.caption,
+      color: c.textMuted,
+      marginTop: 2,
+    },
+    sectionTitle: {
+      ...typography.label,
+      color: c.textMuted,
+      textTransform: "uppercase",
+      paddingHorizontal: spacing.xl,
+      marginBottom: spacing.sm,
+      marginTop: spacing.sm,
+    },
+    themeCard: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: spacing.md,
+      marginHorizontal: spacing.xl,
+      marginBottom: spacing.md,
+      backgroundColor: c.surface,
+      borderRadius: radius.lg,
+      padding: spacing.lg,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    themeInfo: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.md,
+    },
+    themeIconWrap: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: c.primarySoft,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    themeTextos: { flex: 1 },
+    themeLabel: {
+      ...typography.body,
+      fontWeight: "600",
+      color: c.text,
+    },
+    themeSub: {
+      ...typography.caption,
+      color: c.textMuted,
+      marginTop: 2,
+    },
+    linkRow: {
+      paddingHorizontal: spacing.xl,
+      paddingVertical: spacing.sm,
+      marginBottom: spacing.lg,
+    },
+    linkText: {
+      ...typography.caption,
+      color: c.primary,
+      fontWeight: "600",
+    },
+    actionsCard: {
+      marginHorizontal: spacing.xl,
+      marginBottom: spacing.xl,
+    },
+    pressedSoft: {
+      opacity: 0.7,
+    },
+  });
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,11 +5,22 @@ import { useEffect, useState } from "react";
 
 import "@/i18n";
 import { IntroVideo } from "@/components/ui/IntroVideo";
-import { colors } from "@/lib/theme";
+import { ThemeProvider, useTheme } from "@/context/ThemeContext";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
 
 export default function RootLayout() {
+  return (
+    <SafeAreaProvider>
+      <ThemeProvider>
+        <RootStack />
+      </ThemeProvider>
+    </SafeAreaProvider>
+  );
+}
+
+function RootStack() {
+  const { colors, mode, isHydrated: themeHydrated } = useTheme();
   const [introDone, setIntroDone] = useState(false);
   const [ready, setReady] = useState(false);
   const [session, setSession] = useState<Session | null>(null);
@@ -25,14 +36,14 @@ export default function RootLayout() {
     return () => sub.data.subscription.unsubscribe();
   }, []);
 
-  useGuardedRedirect(ready && introDone, session);
+  useGuardedRedirect(ready && introDone && themeHydrated, session);
 
   return (
-    <SafeAreaProvider>
-      <StatusBar style="light" />
+    <>
+      <StatusBar style={mode === "dark" ? "light" : "dark"} />
       {!introDone ? (
         <IntroVideo onFinished={() => setIntroDone(true)} />
-      ) : !ready ? null : (
+      ) : !ready || !themeHydrated ? null : (
         <Stack
           screenOptions={{
             headerStyle: { backgroundColor: colors.bg },
@@ -45,7 +56,7 @@ export default function RootLayout() {
           <Stack.Screen name="lead/[id]" options={{ title: "Lead" }} />
         </Stack>
       )}
-    </SafeAreaProvider>
+    </>
   );
 }
 

--- a/app/lead/[id].tsx
+++ b/app/lead/[id].tsx
@@ -1,16 +1,19 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
+import { useTheme } from "@/context/ThemeContext";
 import { api, ApiError, type Lead } from "@/lib/api";
-import { colors, spacing, typography } from "@/lib/theme";
+import { spacing, typography, type ThemeColors } from "@/lib/theme";
 
 export default function LeadDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
   const [lead, setLead] = useState<Lead | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -23,11 +26,23 @@ export default function LeadDetailScreen() {
       .catch((e) => setError(e instanceof ApiError ? e.message : t("home.error")));
   }, [id]);
 
-  if (error) return <View style={styles.center}><Text style={styles.error}>{error}</Text></View>;
-  if (!lead) return <View style={styles.center}><Text style={styles.muted}>…</Text></View>;
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>{error}</Text>
+      </View>
+    );
+  }
+  if (!lead) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.muted}>…</Text>
+      </View>
+    );
+  }
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScrollView style={styles.container} contentContainerStyle={styles.scroll}>
       <Card style={styles.card}>
         <Text style={styles.vin}>{lead.vin ?? "—"}</Text>
         <View style={styles.row}>
@@ -38,7 +53,9 @@ export default function LeadDetailScreen() {
         {lead.expected_value_brl != null ? (
           <Text style={styles.body}>
             {t("lead.expected_value")}:{" "}
-            {new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(lead.expected_value_brl)}
+            {new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(
+              lead.expected_value_brl,
+            )}
           </Text>
         ) : null}
       </Card>
@@ -46,13 +63,16 @@ export default function LeadDetailScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { padding: spacing.lg, gap: spacing.lg },
-  card: { gap: spacing.md },
-  row: { flexDirection: "row", gap: spacing.sm },
-  vin: { ...typography.h2, color: colors.text },
-  body: { ...typography.body, color: colors.text },
-  muted: { ...typography.body, color: colors.textMuted },
-  error: { ...typography.body, color: colors.danger },
-  center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.bg },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: c.bg },
+    scroll: { padding: spacing.lg, gap: spacing.lg },
+    card: { gap: spacing.md },
+    row: { flexDirection: "row", gap: spacing.sm },
+    vin: { ...typography.h2, color: c.text },
+    body: { ...typography.body, color: c.text },
+    muted: { ...typography.body, color: c.textMuted },
+    error: { ...typography.body, color: c.error },
+    center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: c.bg },
+  });
+}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,74 +1,192 @@
-import { useState } from "react";
-import { StyleSheet, Text, TextInput, View } from "react-native";
+import { useMemo, useState } from "react";
+import {
+  Animated,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { useTheme } from "@/context/ThemeContext";
+import { useFadeIn } from "@/hooks/useFadeIn";
+import { useShake } from "@/hooks/useShake";
 import { signInWithEmail } from "@/lib/auth";
-import { colors, radius, spacing, typography } from "@/lib/theme";
+import { haptic } from "@/lib/haptics";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import {
+  validateEmail,
+  validatePassword,
+  type ValidationError,
+} from "@/lib/validation";
+
+type Errors = {
+  email?: ValidationError;
+  password?: ValidationError;
+};
+
+function validate(values: { email: string; password: string }): Errors {
+  const errors: Errors = {};
+  const email = validateEmail(values.email);
+  if (email) errors.email = email;
+  const password = validatePassword(values.password);
+  if (password) errors.password = password;
+  return errors;
+}
 
 export default function LoginScreen() {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const { translateX, shake } = useShake();
+  const { opacity, translateY } = useFadeIn(360);
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+
+  const errors = useMemo(() => validate({ email, password }), [email, password]);
+  const visibleErrors: Errors = submitted ? errors : {};
+  const hasErrors = Object.keys(errors).length > 0;
+  const buttonDisabled = submitted && hasErrors;
 
   async function onSubmit() {
+    setSubmitted(true);
+    setServerError(null);
+    if (hasErrors) {
+      haptic.error();
+      shake();
+      return;
+    }
     setLoading(true);
-    setError(null);
     try {
       await signInWithEmail(email.trim(), password);
+      haptic.success();
       router.replace("/");
     } catch {
-      setError(t("auth.error"));
+      haptic.error();
+      setServerError(t("auth.error"));
+      shake();
     } finally {
       setLoading(false);
     }
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{t("app.name")}</Text>
-      <View style={styles.form}>
-        <TextInput
-          style={styles.input}
-          autoCapitalize="none"
-          autoComplete="email"
-          keyboardType="email-address"
-          placeholder={t("auth.email")}
-          placeholderTextColor={colors.textMuted}
-          value={email}
-          onChangeText={setEmail}
-        />
-        <TextInput
-          style={styles.input}
-          secureTextEntry
-          placeholder={t("auth.password")}
-          placeholderTextColor={colors.textMuted}
-          value={password}
-          onChangeText={setPassword}
-        />
-        {error ? <Text style={styles.error}>{error}</Text> : null}
-        <Button label={t("auth.sign_in")} loading={loading} onPress={onSubmit} />
-      </View>
-    </View>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <ScrollView
+        contentContainerStyle={[
+          styles.scroll,
+          { paddingTop: insets.top + spacing["4xl"], paddingBottom: insets.bottom + spacing["4xl"] },
+        ]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Animated.View style={[styles.header, { opacity, transform: [{ translateY }] }]}>
+          <Text style={styles.title}>{t("app.name")}</Text>
+          <Text style={styles.subtitle}>{t("auth.subtitle")}</Text>
+        </Animated.View>
+
+        <View style={styles.form}>
+          <Input
+            label={t("auth.email")}
+            placeholder={t("auth.email_placeholder")}
+            icon="mail-outline"
+            value={email}
+            onChangeText={setEmail}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            autoCorrect={false}
+            autoComplete="email"
+            shakeAnim={translateX}
+            error={
+              visibleErrors.email
+                ? t(visibleErrors.email.key, visibleErrors.email.vars)
+                : undefined
+            }
+          />
+          <Input
+            label={t("auth.password")}
+            placeholder="••••••"
+            icon="lock-closed-outline"
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            autoCapitalize="none"
+            autoComplete="password"
+            shakeAnim={translateX}
+            error={
+              visibleErrors.password
+                ? t(visibleErrors.password.key, visibleErrors.password.vars)
+                : undefined
+            }
+          />
+
+          {serverError ? (
+            <View style={styles.serverErrorBox}>
+              <Text style={styles.serverErrorText}>{serverError}</Text>
+            </View>
+          ) : null}
+
+          <Button
+            label={t("auth.sign_in")}
+            loading={loading}
+            disabled={buttonDisabled}
+            onPress={onSubmit}
+            style={styles.submit}
+          />
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, padding: spacing.xl, gap: spacing.xxl, backgroundColor: colors.bg, justifyContent: "center" },
-  title: { ...typography.h1, color: colors.text, textAlign: "center" },
-  form: { gap: spacing.md },
-  input: {
-    height: 48,
-    paddingHorizontal: spacing.lg,
-    borderRadius: radius.md,
-    backgroundColor: colors.surface,
-    borderWidth: 1,
-    borderColor: colors.border,
-    color: colors.text,
-    ...typography.body,
-  },
-  error: { ...typography.body, color: colors.danger },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: c.bg },
+    scroll: {
+      flexGrow: 1,
+      paddingHorizontal: spacing.xl,
+      justifyContent: "center",
+    },
+    header: {
+      alignItems: "center",
+      marginBottom: spacing["2xl"],
+    },
+    title: { ...typography.h1, color: c.text },
+    subtitle: {
+      ...typography.body,
+      color: c.textMuted,
+      marginTop: spacing.sm,
+    },
+    form: { width: "100%" },
+    serverErrorBox: {
+      borderWidth: 1,
+      borderColor: c.error,
+      backgroundColor: c.errorSoft,
+      borderRadius: radius.md,
+      padding: spacing.md,
+      marginTop: spacing.xs,
+      marginBottom: spacing.md,
+    },
+    serverErrorText: {
+      ...typography.caption,
+      fontWeight: "600",
+      color: c.error,
+      textAlign: "center",
+    },
+    submit: { marginTop: spacing.md },
+  });
+}

--- a/components/domain/LeadCard.tsx
+++ b/components/domain/LeadCard.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
+import { useTheme } from "@/context/ThemeContext";
 import type { Lead } from "@/lib/api";
-import { colors, spacing, typography, type ColorToken } from "@/lib/theme";
+import { spacing, typography, type ColorToken, type ThemeColors } from "@/lib/theme";
 
 const priorityTone: Record<Lead["priority"], ColorToken> = {
   low: "textMuted",
@@ -16,6 +17,9 @@ const priorityTone: Record<Lead["priority"], ColorToken> = {
 
 export function LeadCard({ lead }: { lead: Lead }) {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
   return (
     <Card style={styles.card}>
       <View style={styles.row}>
@@ -27,7 +31,9 @@ export function LeadCard({ lead }: { lead: Lead }) {
         <Badge label={t(`status.${lead.status}`)} tone="textMuted" />
         {lead.expected_value_brl != null ? (
           <Text style={styles.value}>
-            {new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(lead.expected_value_brl)}
+            {new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(
+              lead.expected_value_brl,
+            )}
           </Text>
         ) : null}
       </View>
@@ -35,10 +41,12 @@ export function LeadCard({ lead }: { lead: Lead }) {
   );
 }
 
-const styles = StyleSheet.create({
-  card: { gap: spacing.sm },
-  row: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
-  vin: { ...typography.h3, color: colors.text },
-  reason: { ...typography.body, color: colors.textMuted },
-  value: { ...typography.body, color: colors.text, fontWeight: "600" },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    card: { gap: spacing.sm },
+    row: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+    vin: { ...typography.h3, color: c.text },
+    reason: { ...typography.body, color: c.textMuted },
+    value: { ...typography.body, color: c.text, fontWeight: "600" },
+  });
+}

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { colors, radius, spacing, typography, type ColorToken } from "@/lib/theme";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ColorToken, type ThemeColors } from "@/lib/theme";
 
 export interface BadgeProps {
   label: string;
@@ -8,7 +10,11 @@ export interface BadgeProps {
 }
 
 export function Badge({ label, tone = "primary" }: BadgeProps) {
+  const { colors } = useTheme();
   const color = colors[tone];
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  // Translucent fill (22 hex = ~13%) + solid border + solid text in the same hue.
+  // Fundo translucido + borda solida + texto na mesma matiz.
   return (
     <View style={[styles.wrap, { backgroundColor: color + "22", borderColor: color }]}>
       <Text style={[styles.text, { color }]}>{label}</Text>
@@ -16,13 +22,15 @@ export function Badge({ label, tone = "primary" }: BadgeProps) {
   );
 }
 
-const styles = StyleSheet.create({
-  wrap: {
-    alignSelf: "flex-start",
-    paddingHorizontal: spacing.sm,
-    paddingVertical: 2,
-    borderRadius: radius.pill,
-    borderWidth: 1,
-  },
-  text: { ...typography.label, textTransform: "uppercase" },
-});
+function createStyles(_c: ThemeColors) {
+  return StyleSheet.create({
+    wrap: {
+      alignSelf: "flex-start",
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: radius.pill,
+      borderWidth: 1,
+    },
+    text: { ...typography.label, textTransform: "uppercase" },
+  });
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,6 +1,15 @@
-import React from "react";
-import { ActivityIndicator, Pressable, StyleSheet, Text, type PressableProps } from "react-native";
-import { colors, radius, spacing, typography } from "@/lib/theme";
+import React, { useMemo, useRef } from "react";
+import {
+  ActivityIndicator,
+  Animated,
+  Pressable,
+  StyleSheet,
+  Text,
+  type PressableProps,
+} from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
 type Variant = "primary" | "secondary" | "ghost";
 
@@ -10,39 +19,89 @@ export interface ButtonProps extends Omit<PressableProps, "children"> {
   loading?: boolean;
 }
 
-export function Button({ label, variant = "primary", loading, disabled, style, ...rest }: ButtonProps) {
+export function Button({
+  label,
+  variant = "primary",
+  loading,
+  disabled,
+  style,
+  ...rest
+}: ButtonProps) {
+  const { colors, elevation } = useTheme();
+  const scale = useRef(new Animated.Value(1)).current;
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  // Spring scale on press — pressIn snaps in fast, pressOut bounces back a hair.
+  // O contraste das curvas eh o que faz o botao "ter peso".
+  const handlePressIn = () => {
+    Animated.spring(scale, {
+      toValue: 0.97,
+      useNativeDriver: true,
+      speed: 60,
+      bounciness: 0,
+    }).start();
+  };
+  const handlePressOut = () => {
+    Animated.spring(scale, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 60,
+      bounciness: 6,
+    }).start();
+  };
+
+  const variantStyle = styles[variant];
+  const labelStyle =
+    variant === "ghost"
+      ? [styles.label, { color: colors.primary }]
+      : variant === "secondary"
+        ? [styles.label, { color: colors.text }]
+        : [styles.label, { color: colors.primaryText }];
+  const indicatorColor = variant === "primary" ? colors.primaryText : colors.primary;
+
   return (
-    <Pressable
-      {...rest}
-      disabled={disabled || loading}
-      style={({ pressed }) => [
-        styles.base,
-        variant === "primary" && styles.primary,
-        variant === "secondary" && styles.secondary,
-        variant === "ghost" && styles.ghost,
-        (pressed || disabled) && { opacity: disabled ? 0.5 : 0.75 },
-        typeof style === "function" ? style({ pressed } as never) : style,
-      ]}
-    >
-      {loading ? (
-        <ActivityIndicator color={colors.text} />
-      ) : (
-        <Text style={[styles.label, variant === "ghost" && { color: colors.primary }]}>{label}</Text>
-      )}
-    </Pressable>
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <Pressable
+        {...rest}
+        disabled={disabled || loading}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: disabled || loading, busy: loading }}
+        style={({ pressed }) => [
+          styles.base,
+          variantStyle,
+          variant === "primary" ? elevation.primary : undefined,
+          disabled ? { opacity: 0.45 } : pressed ? { opacity: 0.9 } : undefined,
+          typeof style === "function" ? style({ pressed } as never) : style,
+        ]}
+      >
+        {loading ? (
+          <ActivityIndicator color={indicatorColor} />
+        ) : (
+          <Text style={labelStyle}>{label}</Text>
+        )}
+      </Pressable>
+    </Animated.View>
   );
 }
 
-const styles = StyleSheet.create({
-  base: {
-    height: 48,
-    paddingHorizontal: spacing.lg,
-    borderRadius: radius.md,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  primary: { backgroundColor: colors.primary },
-  secondary: { backgroundColor: colors.surfaceAlt, borderWidth: 1, borderColor: colors.border },
-  ghost: { backgroundColor: "transparent" },
-  label: { ...typography.h3, color: colors.text },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    base: {
+      height: 48,
+      paddingHorizontal: spacing.lg,
+      borderRadius: radius.md,
+      alignItems: "center",
+      justifyContent: "center",
+      borderWidth: 1,
+      borderColor: "transparent",
+    },
+    primary: { backgroundColor: c.primary, borderColor: c.primary },
+    secondary: { backgroundColor: c.surface, borderColor: c.border },
+    ghost: { backgroundColor: "transparent", borderColor: c.borderStrong },
+    label: {
+      ...typography.h3,
+    },
+  });
+}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,17 +1,23 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { StyleSheet, View, type ViewProps } from "react-native";
-import { colors, radius, spacing } from "@/lib/theme";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, type ThemeColors } from "@/lib/theme";
 
 export function Card({ style, ...rest }: ViewProps) {
-  return <View {...rest} style={[styles.card, style]} />;
+  const { colors, elevation } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  return <View {...rest} style={[styles.card, elevation.sm, style]} />;
 }
 
-const styles = StyleSheet.create({
-  card: {
-    backgroundColor: colors.surface,
-    borderRadius: radius.lg,
-    padding: spacing.lg,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    card: {
+      backgroundColor: c.surface,
+      borderRadius: radius.lg,
+      padding: spacing.lg,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+  });
+}

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,64 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useMemo, type ReactNode } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { spacing, typography, type ThemeColors } from "@/lib/theme";
+
+export interface EmptyStateProps {
+  icon?: keyof typeof Ionicons.glyphMap;
+  title: string;
+  description?: string;
+  /** Optional action element — usually a <Button />. */
+  action?: ReactNode;
+}
+
+export function EmptyState({ icon = "search-outline", title, description, action }: EmptyStateProps) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconWrap}>
+        <Ionicons name={icon} size={28} color={colors.textMuted} />
+      </View>
+      <Text style={styles.title}>{title}</Text>
+      {description ? <Text style={styles.description}>{description}</Text> : null}
+      {action ? <View style={styles.action}>{action}</View> : null}
+    </View>
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      alignItems: "center",
+      paddingVertical: spacing["3xl"],
+      paddingHorizontal: spacing.xl,
+      gap: spacing.sm,
+    },
+    iconWrap: {
+      width: 56,
+      height: 56,
+      borderRadius: 28,
+      backgroundColor: c.surface,
+      borderWidth: 1,
+      borderColor: c.border,
+      alignItems: "center",
+      justifyContent: "center",
+      marginBottom: spacing.md,
+    },
+    title: {
+      ...typography.h3,
+      color: c.text,
+      textAlign: "center",
+    },
+    description: {
+      ...typography.body,
+      color: c.textMuted,
+      textAlign: "center",
+      maxWidth: 320,
+    },
+    action: { marginTop: spacing.lg },
+  });
+}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,118 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type TextInputProps,
+} from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+
+export interface InputProps extends TextInputProps {
+  label?: string;
+  /** Already-translated error message. Pass undefined/null when valid. */
+  error?: string | null;
+  icon?: keyof typeof Ionicons.glyphMap;
+  rightSlot?: ReactNode;
+  /** When supplied, wraps the input in an Animated.View so useShake() can drive translateX. */
+  shakeAnim?: Animated.Value;
+}
+
+export function Input({
+  label,
+  error,
+  icon,
+  rightSlot,
+  shakeAnim,
+  ...inputProps
+}: InputProps) {
+  const { colors } = useTheme();
+  const [focused, setFocused] = useState(false);
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  // Border priority: error wins > focused wins > default. Same rule for the icon tint.
+  // Prioridade da borda: erro > focado > default. Mesma regra pro tint do icone.
+  const borderColor = error
+    ? colors.error
+    : focused
+      ? colors.primary
+      : colors.border;
+  const iconColor = error
+    ? colors.error
+    : focused
+      ? colors.primary
+      : colors.textSubtle;
+
+  const content = (
+    <>
+      {label ? <Text style={styles.label}>{label}</Text> : null}
+      <View style={[styles.field, { borderColor }]}>
+        {icon ? (
+          <Ionicons name={icon} size={18} color={iconColor} style={styles.icon} />
+        ) : null}
+        <TextInput
+          {...inputProps}
+          placeholderTextColor={colors.textSubtle}
+          style={[styles.input, inputProps.style]}
+          onFocus={(e) => {
+            setFocused(true);
+            inputProps.onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setFocused(false);
+            inputProps.onBlur?.(e);
+          }}
+        />
+        {rightSlot}
+      </View>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+    </>
+  );
+
+  if (shakeAnim) {
+    return (
+      <Animated.View style={[styles.wrapper, { transform: [{ translateX: shakeAnim }] }]}>
+        {content}
+      </Animated.View>
+    );
+  }
+  return <View style={styles.wrapper}>{content}</View>;
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    wrapper: { marginBottom: spacing.md },
+    label: {
+      ...typography.caption,
+      fontWeight: "600",
+      color: c.textMuted,
+      marginBottom: spacing.sm,
+    },
+    field: {
+      flexDirection: "row",
+      alignItems: "center",
+      borderWidth: 1,
+      borderRadius: radius.md,
+      paddingHorizontal: spacing.md,
+      backgroundColor: c.inputBg,
+    },
+    icon: { marginRight: spacing.sm },
+    input: {
+      flex: 1,
+      paddingVertical: spacing.md + 2,
+      fontSize: 16,
+      color: c.text,
+    },
+    error: {
+      ...typography.caption,
+      fontWeight: "500",
+      color: c.error,
+      marginTop: spacing.xs + 2,
+      marginLeft: spacing.xs,
+    },
+  });
+}

--- a/components/ui/IntroVideo.tsx
+++ b/components/ui/IntroVideo.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Pressable, StyleSheet, Text, useWindowDimensions } from "react-native";
 import Animated, {
   runOnJS,
@@ -9,7 +9,8 @@ import Animated, {
 import { useVideoPlayer, VideoView } from "expo-video";
 import { useTranslation } from "react-i18next";
 
-import { colors, radius, spacing, typography } from "@/lib/theme";
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
 // Local asset — bundled into the binary, no runtime download.
 // Asset local — empacotado no binario, sem download em runtime.
@@ -23,6 +24,8 @@ export interface IntroVideoProps {
 
 export function IntroVideo({ onFinished }: IntroVideoProps) {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
   const { width, height } = useWindowDimensions();
   const opacity = useSharedValue(1);
   const finished = useRef(false);
@@ -61,38 +64,35 @@ export function IntroVideo({ onFinished }: IntroVideoProps) {
           allowsPictureInPicture={false}
         />
       </Pressable>
-      <Pressable
-        onPress={finish}
-        hitSlop={12}
-        style={styles.skip}
-        accessibilityRole="button"
-      >
+      <Pressable onPress={finish} hitSlop={12} style={styles.skip} accessibilityRole="button">
         <Text style={styles.skipLabel}>{t("intro.skip")}</Text>
       </Pressable>
     </Animated.View>
   );
 }
 
-const styles = StyleSheet.create({
-  root: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: colors.bg,
-    zIndex: 100,
-  },
-  fill: { flex: 1 },
-  skip: {
-    position: "absolute",
-    top: spacing.xxl + spacing.md,
-    right: spacing.lg,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.xs,
-    borderRadius: radius.pill,
-    backgroundColor: "rgba(11,18,32,0.55)",
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  skipLabel: {
-    ...typography.caption,
-    color: colors.text,
-  },
-});
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    root: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: c.bg,
+      zIndex: 100,
+    },
+    fill: { flex: 1 },
+    skip: {
+      position: "absolute",
+      top: spacing["3xl"] + spacing.md,
+      right: spacing.lg,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.xs,
+      borderRadius: radius.pill,
+      backgroundColor: "rgba(11,18,32,0.55)",
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    skipLabel: {
+      ...typography.caption,
+      color: "#FFFFFF",
+    },
+  });
+}

--- a/components/ui/LoadingScreen.tsx
+++ b/components/ui/LoadingScreen.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useRef } from "react";
+import { Animated, StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { spacing, typography, type ThemeColors } from "@/lib/theme";
+
+export interface LoadingScreenProps {
+  label?: string;
+  subtitle?: string;
+  /** Inline mode renders just the dots + label (no full-screen wrapper). */
+  inline?: boolean;
+}
+
+const DOT_DELAY_MS = 180;
+
+export function LoadingScreen({ label, subtitle, inline = false }: LoadingScreenProps) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  if (inline) {
+    return (
+      <View style={styles.inline}>
+        <View style={styles.dots}>
+          <Dot delay={0} color={colors.primary} />
+          <Dot delay={DOT_DELAY_MS} color={colors.primary} />
+          <Dot delay={DOT_DELAY_MS * 2} color={colors.primary} />
+        </View>
+        {label ? <Text style={styles.label}>{label}</Text> : null}
+        {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <View style={styles.dots}>
+          <Dot delay={0} color={colors.primary} />
+          <Dot delay={DOT_DELAY_MS} color={colors.primary} />
+          <Dot delay={DOT_DELAY_MS * 2} color={colors.primary} />
+        </View>
+        {label ? <Text style={styles.label}>{label}</Text> : null}
+        {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+function Dot({ delay, color }: { delay: number; color: string }) {
+  const opacity = useRef(new Animated.Value(0.25)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.delay(delay),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 360,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.25,
+          duration: 360,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [opacity, delay]);
+
+  return <Animated.View style={[dotStyles.dot, { backgroundColor: color, opacity }]} />;
+}
+
+const dotStyles = StyleSheet.create({
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+});
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: c.bg,
+    },
+    inline: {
+      alignItems: "center",
+      justifyContent: "center",
+      paddingVertical: spacing["3xl"],
+    },
+    content: { alignItems: "center" },
+    dots: {
+      flexDirection: "row",
+      gap: spacing.xs + 2,
+      marginBottom: spacing.xl,
+    },
+    label: {
+      ...typography.body,
+      fontWeight: "700",
+      color: c.text,
+    },
+    subtitle: {
+      ...typography.caption,
+      color: c.textMuted,
+      marginTop: spacing.xs,
+      textAlign: "center",
+      paddingHorizontal: spacing["2xl"],
+    },
+  });
+}

--- a/components/ui/ProfileAvatar.tsx
+++ b/components/ui/ProfileAvatar.tsx
@@ -1,0 +1,70 @@
+import { useMemo, useState } from "react";
+import { Image, StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import type { ThemeColors } from "@/lib/theme";
+
+export interface ProfileAvatarProps {
+  uri?: string | null;
+  /** Used to derive initials when no photo is available. Pass full name or email. */
+  source: string;
+  size?: number;
+}
+
+export function ProfileAvatar({ uri, source, size = 96 }: ProfileAvatarProps) {
+  const { colors } = useTheme();
+  const [loadError, setLoadError] = useState(false);
+  const styles = useMemo(() => createStyles(colors, size), [colors, size]);
+
+  const showImage = !!uri && !loadError;
+
+  if (showImage) {
+    return (
+      <Image
+        source={{ uri: uri as string }}
+        style={styles.avatar}
+        onError={() => setLoadError(true)}
+      />
+    );
+  }
+
+  return (
+    <View style={[styles.avatar, styles.placeholder]}>
+      <Text style={styles.initials}>{getInitials(source)}</Text>
+    </View>
+  );
+}
+
+function getInitials(source: string): string {
+  const trimmed = source.trim();
+  if (!trimmed) return "?";
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) {
+    return (parts[0]?.charAt(0) ?? "?").toUpperCase();
+  }
+  const first = parts[0]?.charAt(0) ?? "";
+  const last = parts[parts.length - 1]?.charAt(0) ?? "";
+  return `${first}${last}`.toUpperCase();
+}
+
+function createStyles(c: ThemeColors, size: number) {
+  return StyleSheet.create({
+    avatar: {
+      width: size,
+      height: size,
+      borderRadius: size / 2,
+      borderWidth: 2,
+      borderColor: c.primary,
+    },
+    placeholder: {
+      backgroundColor: c.surfaceElevated,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    initials: {
+      fontSize: size * 0.4,
+      fontWeight: "800",
+      color: c.primary,
+    },
+  });
+}

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useRef } from "react";
+import { Animated, StyleSheet, type ViewStyle } from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, type ThemeColors } from "@/lib/theme";
+
+export interface SkeletonProps {
+  width?: number | `${number}%`;
+  height?: number;
+  borderRadius?: number;
+  style?: ViewStyle;
+}
+
+export function Skeleton({
+  width = "100%",
+  height = 16,
+  borderRadius = radius.sm,
+  style,
+}: SkeletonProps) {
+  const { colors } = useTheme();
+  const opacity = useRef(new Animated.Value(0.4)).current;
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.9,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.4,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.base,
+        { width, height, borderRadius, opacity },
+        style,
+      ]}
+    />
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    base: {
+      backgroundColor: c.surfaceElevated,
+    },
+  });
+}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,127 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useMemo, useRef } from "react";
+import { Animated, StyleSheet, Text } from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+
+export type ToastVariant = "success" | "error" | "info";
+
+export interface ToastProps {
+  message: string;
+  variant?: ToastVariant;
+  visible: boolean;
+  onHide: () => void;
+  duration?: number;
+}
+
+const ENTER_OFFSET = -120;
+
+export function Toast({
+  message,
+  variant = "success",
+  visible,
+  onHide,
+  duration = 2500,
+}: ToastProps) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const translateY = useRef(new Animated.Value(ENTER_OFFSET)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (!visible) return;
+    Animated.parallel([
+      Animated.spring(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+        speed: 14,
+        bounciness: 6,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 220,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    const timer = setTimeout(() => {
+      Animated.parallel([
+        Animated.timing(translateY, {
+          toValue: ENTER_OFFSET,
+          duration: 280,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: 220,
+          useNativeDriver: true,
+        }),
+      ]).start(() => onHide());
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [visible, duration, translateY, opacity, onHide]);
+
+  if (!visible) return null;
+
+  const iconName: keyof typeof Ionicons.glyphMap =
+    variant === "success"
+      ? "checkmark-circle"
+      : variant === "error"
+        ? "alert-circle"
+        : "information-circle";
+
+  const accent =
+    variant === "success"
+      ? colors.success
+      : variant === "error"
+        ? colors.error
+        : colors.primary;
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.container,
+        { borderLeftColor: accent, opacity, transform: [{ translateY }] },
+      ]}
+    >
+      <Ionicons name={iconName} size={20} color={accent} />
+      <Text style={styles.message} numberOfLines={2}>
+        {message}
+      </Text>
+    </Animated.View>
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      position: "absolute",
+      top: 60,
+      left: spacing.xl,
+      right: spacing.xl,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.md,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.lg,
+      borderRadius: radius.md,
+      borderLeftWidth: 3,
+      backgroundColor: c.surface,
+      zIndex: 1000,
+      elevation: 8,
+      shadowColor: "#000",
+      shadowOpacity: 0.2,
+      shadowRadius: 12,
+      shadowOffset: { width: 0, height: 4 },
+    },
+    message: {
+      flex: 1,
+      ...typography.body,
+      fontWeight: "600",
+      color: c.text,
+    },
+  });
+}

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -1,0 +1,178 @@
+// ThemeProvider: tracks system color scheme by default, lets the user override
+// via toggleTheme/setTheme. Override persists in AsyncStorage. Transitions
+// use a full-screen overlay fade (320ms) to avoid a jarring color flash.
+// Provider de tema: segue o sistema, override manual persiste, cross-fade animado.
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Animated, StyleSheet, useColorScheme, View } from "react-native";
+
+import { STORAGE_KEYS } from "@/lib/storage-keys";
+import {
+  elevationDark,
+  elevationLight,
+  palette,
+  type Elevation,
+  type ThemeColors,
+  type ThemeMode,
+} from "@/lib/theme";
+
+type ThemeContextValue = {
+  mode: ThemeMode;
+  colors: ThemeColors;
+  elevation: Elevation;
+  /** true when there is a stored user override; false when following system. */
+  isOverridden: boolean;
+  /** true when AsyncStorage hydration finished — gate splash screens on this. */
+  isHydrated: boolean;
+  toggleTheme: () => void;
+  setTheme: (mode: ThemeMode) => void;
+  /** Clear override and follow useColorScheme() again. */
+  resetToSystem: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const FADE_DURATION_MS = 320;
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  return value === "light" || value === "dark";
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const systemScheme = useColorScheme();
+  const systemMode: ThemeMode = systemScheme === "light" ? "light" : "dark";
+
+  // override === null means "follow system"; otherwise it pins the mode.
+  const [override, setOverride] = useState<ThemeMode | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  // Cross-fade overlay — when the mode flips, we capture the old bg color,
+  // paint it on top, then fade to 0 to reveal the new palette underneath.
+  const overlayOpacity = useRef(new Animated.Value(0)).current;
+  const [overlayColor, setOverlayColor] = useState<string | null>(null);
+
+  // Boot: read stored override. If absent, keep null (follow system).
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEYS.THEME)
+      .then((stored: string | null) => {
+        if (cancelled) return;
+        if (isThemeMode(stored)) setOverride(stored);
+      })
+      .finally(() => {
+        if (!cancelled) setIsHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const mode: ThemeMode = override ?? systemMode;
+
+  const animateTransition = useCallback(
+    (fromMode: ThemeMode) => {
+      setOverlayColor(palette[fromMode].bg);
+      overlayOpacity.setValue(1);
+      Animated.timing(overlayOpacity, {
+        toValue: 0,
+        duration: FADE_DURATION_MS,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) setOverlayColor(null);
+      });
+    },
+    [overlayOpacity],
+  );
+
+  const persistOverride = useCallback((next: ThemeMode | null) => {
+    if (next === null) {
+      AsyncStorage.removeItem(STORAGE_KEYS.THEME).catch(() => {
+        // storage failures should not block UX
+      });
+    } else {
+      AsyncStorage.setItem(STORAGE_KEYS.THEME, next).catch(() => {
+        // storage failures should not block UX
+      });
+    }
+  }, []);
+
+  const setTheme = useCallback(
+    (next: ThemeMode) => {
+      const prev = override ?? systemMode;
+      if (prev !== next) animateTransition(prev);
+      setOverride(next);
+      persistOverride(next);
+    },
+    [override, systemMode, animateTransition, persistOverride],
+  );
+
+  const toggleTheme = useCallback(() => {
+    const prev = override ?? systemMode;
+    const next: ThemeMode = prev === "dark" ? "light" : "dark";
+    animateTransition(prev);
+    setOverride(next);
+    persistOverride(next);
+  }, [override, systemMode, animateTransition, persistOverride]);
+
+  const resetToSystem = useCallback(() => {
+    const prev = override ?? systemMode;
+    if (prev !== systemMode) animateTransition(prev);
+    setOverride(null);
+    persistOverride(null);
+  }, [override, systemMode, animateTransition, persistOverride]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      mode,
+      colors: palette[mode],
+      elevation: mode === "dark" ? elevationDark : elevationLight,
+      isOverridden: override !== null,
+      isHydrated,
+      toggleTheme,
+      setTheme,
+      resetToSystem,
+    }),
+    [mode, override, isHydrated, toggleTheme, setTheme, resetToSystem],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <View style={styles.root}>
+        {children}
+        {overlayColor ? (
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              StyleSheet.absoluteFillObject,
+              styles.overlay,
+              { backgroundColor: overlayColor, opacity: overlayOpacity },
+            ]}
+          />
+        ) : null}
+      </View>
+    </ThemeContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+  overlay: { zIndex: 9999 },
+});
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used inside <ThemeProvider>");
+  }
+  return ctx;
+}

--- a/hooks/useFadeIn.ts
+++ b/hooks/useFadeIn.ts
@@ -1,0 +1,29 @@
+// Fade-in + small upward translate on mount. Spread the returned values onto
+// an Animated.View {opacity, transform: [{translateY}]}. Use to give static
+// content a gentle "appear" rather than a hard pop on screen mount.
+// Fade-in + leve subida ao montar — entrada suave para conteudo estatico.
+
+import { useEffect, useRef } from "react";
+import { Animated } from "react-native";
+
+export function useFadeIn(duration = 320, fromY = 12) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(fromY)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration,
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateY, {
+        toValue: 0,
+        duration,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [opacity, translateY, duration]);
+
+  return { opacity, translateY };
+}

--- a/hooks/useShake.ts
+++ b/hooks/useShake.ts
@@ -1,0 +1,41 @@
+// Horizontal shake animation — call shake() to trigger a quick "no" gesture.
+// Spread translateX onto an Animated.View transform. Useful for form errors.
+// Animacao de shake horizontal — gesto de "no" rapido para erro de form.
+
+import { useRef } from "react";
+import { Animated } from "react-native";
+
+const DISPLACEMENT = 8;
+const STEP_DURATION = 60;
+
+export function useShake() {
+  const translateX = useRef(new Animated.Value(0)).current;
+
+  function shake() {
+    translateX.setValue(0);
+    Animated.sequence([
+      Animated.timing(translateX, {
+        toValue: -DISPLACEMENT,
+        duration: STEP_DURATION,
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateX, {
+        toValue: DISPLACEMENT,
+        duration: STEP_DURATION,
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateX, {
+        toValue: -DISPLACEMENT / 2,
+        duration: STEP_DURATION,
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateX, {
+        toValue: 0,
+        duration: STEP_DURATION,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }
+
+  return { translateX, shake };
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,7 +4,9 @@
   "auth": {
     "sign_in": "Sign in",
     "email": "Email",
+    "email_placeholder": "you@company.com",
     "password": "Password",
+    "subtitle": "Welcome. Sign in to access your leads.",
     "loading": "Loading",
     "error": "Could not sign in. Check your credentials."
   },
@@ -18,7 +20,21 @@
     "greeting": "Hello",
     "todays_leads": "Today's leads",
     "empty": "No leads at the moment",
+    "empty_title": "No leads yet",
+    "empty_description": "When new leads are assigned to you, they will show up here.",
     "error": "Failed to load data"
+  },
+  "loading": {
+    "profile": "Loading profile"
+  },
+  "validation": {
+    "email_required": "Enter your email",
+    "email_invalid": "Invalid email",
+    "password_required": "Enter your password",
+    "password_too_short": "Password needs at least {{count}} characters",
+    "name_required": "Enter your name",
+    "name_short": "Name is too short",
+    "required": "Required field"
   },
   "lead": {
     "priority": "Priority",
@@ -49,5 +65,15 @@
     "lost": "Lost",
     "expired": "Expired"
   },
-  "profile": { "sign_out": "Sign out" }
+  "profile": {
+    "sign_out": "Sign out",
+    "unnamed": "Unnamed",
+    "account": "Account",
+    "appearance": "Appearance",
+    "dark_mode": "Dark mode",
+    "light_mode": "Light mode",
+    "theme_auto": "Following system",
+    "theme_manual": "Manual override active",
+    "follow_system": "Follow system again"
+  }
 }

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -8,7 +8,9 @@
   "auth": {
     "sign_in": "Entrar",
     "email": "E-mail",
+    "email_placeholder": "voce@empresa.com",
     "password": "Senha",
+    "subtitle": "Bem-vindo. Entre para acessar seus leads.",
     "loading": "Carregando",
     "error": "Nao foi possivel entrar. Verifique suas credenciais."
   },
@@ -22,7 +24,21 @@
     "greeting": "Ola",
     "todays_leads": "Leads de hoje",
     "empty": "Nenhum lead no momento",
+    "empty_title": "Sem leads por enquanto",
+    "empty_description": "Quando novos leads forem atribuidos a voce, eles aparecem aqui.",
     "error": "Falha ao carregar dados"
+  },
+  "loading": {
+    "profile": "Carregando perfil"
+  },
+  "validation": {
+    "email_required": "Informe seu e-mail",
+    "email_invalid": "E-mail invalido",
+    "password_required": "Informe sua senha",
+    "password_too_short": "Senha precisa de pelo menos {{count}} caracteres",
+    "name_required": "Informe seu nome",
+    "name_short": "Nome muito curto",
+    "required": "Campo obrigatorio"
   },
   "lead": {
     "priority": "Prioridade",
@@ -54,6 +70,14 @@
     "expired": "Expirado"
   },
   "profile": {
-    "sign_out": "Sair"
+    "sign_out": "Sair",
+    "unnamed": "Sem nome",
+    "account": "Conta",
+    "appearance": "Aparencia",
+    "dark_mode": "Modo escuro",
+    "light_mode": "Modo claro",
+    "theme_auto": "Seguindo o sistema",
+    "theme_manual": "Override manual ativo",
+    "follow_system": "Voltar a seguir o sistema"
   }
 }

--- a/lib/haptics.ts
+++ b/lib/haptics.ts
@@ -1,0 +1,30 @@
+// Haptic feedback wrapper. Swallows errors silently so the sim/web don't crash
+// when there is no haptic engine available.
+// Wrapper de haptics — silencia falhas no simulador/web.
+
+import * as Haptics from "expo-haptics";
+import { Platform } from "react-native";
+
+const supported = Platform.OS === "ios" || Platform.OS === "android";
+
+function safe(call: () => Promise<void> | void) {
+  if (!supported) return;
+  try {
+    void call();
+  } catch {
+    // simulator/web may fail — silenced
+  }
+}
+
+export const haptic = {
+  light: () => safe(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)),
+  medium: () => safe(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)),
+  heavy: () => safe(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)),
+  selection: () => safe(() => Haptics.selectionAsync()),
+  success: () =>
+    safe(() => Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)),
+  warning: () =>
+    safe(() => Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning)),
+  error: () =>
+    safe(() => Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error)),
+};

--- a/lib/storage-keys.ts
+++ b/lib/storage-keys.ts
@@ -1,0 +1,13 @@
+// Centralised storage keys for AsyncStorage. Never use string literals in
+// callers — keep the namespace in one place so a rename or audit is safe.
+// Chaves de storage centralizadas; proibido usar string literal nos consumers.
+
+export const STORAGE_KEYS = {
+  THEME: "@forward:theme",
+  LOCALE: "@forward:locale",
+  ONBOARDED: "@forward:onboarded",
+  CURRENT_DEALER_ID: "@forward:current_dealer_id",
+  LAST_USER: "@forward:last_user",
+} as const;
+
+export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,20 +1,134 @@
 // Design tokens for the ForwardService mobile app.
-// Centralised so UI primitives and screens never hardcode values.
-// Tokens de design: cores, espacamento, tipografia.
+// Two palettes (light + dark) keyed by semantic tokens. Screens consume via
+// useTheme() — never import `palette` directly.
+// Tokens de design: paletas light/dark, espacamento, tipografia, elevacao.
 
-export const colors = {
-  bg: "#0B1220",
-  surface: "#121A2B",
-  surfaceAlt: "#1A2336",
-  border: "#24304A",
-  text: "#E6EDF7",
-  textMuted: "#93A1B8",
-  primary: "#3366FF",
-  primaryAlt: "#1E4CFF",
-  success: "#2DB67B",
-  warning: "#E3A93C",
-  danger: "#E5484D",
-  critical: "#FF5463",
+export type ThemeMode = "light" | "dark";
+
+export type ThemeColors = {
+  bg: string;
+  bgElevated: string;
+  surface: string;
+  surfaceElevated: string;
+  surfaceHover: string;
+  border: string;
+  borderStrong: string;
+  separator: string;
+  text: string;
+  textMuted: string;
+  textSubtle: string;
+  primary: string;
+  primaryDeep: string;
+  primaryText: string;
+  primarySoft: string;
+  success: string;
+  successSoft: string;
+  warning: string;
+  warningSoft: string;
+  error: string;
+  errorSoft: string;
+  critical: string;
+  overlay: string;
+  tabBar: string;
+  inputBg: string;
+};
+
+// Ford Blue is the brand primary. Light uses the classic deep blue; dark uses
+// a lighter, more saturated variant for legibility on dark backgrounds.
+// Azul Ford classico (#003478) no light; variante mais clara no dark.
+export const FORD_BLUE = "#003478";
+export const FORD_BLUE_DEEP = "#002356";
+export const FORD_BLUE_DARK_MODE = "#5B8DEF";
+export const FORD_BLUE_DARK_MODE_DEEP = "#3D6FCC";
+
+export const palette: Record<ThemeMode, ThemeColors> = {
+  light: {
+    bg: "#F7F8FA",
+    bgElevated: "#FFFFFF",
+    surface: "#FFFFFF",
+    surfaceElevated: "#FFFFFF",
+    surfaceHover: "#F1F3F7",
+    border: "rgba(11, 18, 32, 0.08)",
+    borderStrong: "rgba(11, 18, 32, 0.14)",
+    separator: "rgba(11, 18, 32, 0.05)",
+    text: "#0B1220",
+    textMuted: "#56627A",
+    textSubtle: "#8E97AC",
+    primary: FORD_BLUE,
+    primaryDeep: FORD_BLUE_DEEP,
+    primaryText: "#FFFFFF",
+    primarySoft: "rgba(0, 52, 120, 0.10)",
+    success: "#0F8A5F",
+    successSoft: "rgba(15, 138, 95, 0.10)",
+    warning: "#B5670A",
+    warningSoft: "rgba(181, 103, 10, 0.10)",
+    error: "#C7363A",
+    errorSoft: "rgba(199, 54, 58, 0.10)",
+    critical: "#A11A20",
+    overlay: "rgba(11, 18, 32, 0.40)",
+    tabBar: "rgba(255, 255, 255, 0.92)",
+    inputBg: "#FFFFFF",
+  },
+  dark: {
+    bg: "#0B1220",
+    bgElevated: "#101A2E",
+    surface: "#121A2B",
+    surfaceElevated: "#1A2336",
+    surfaceHover: "#1F2A40",
+    border: "rgba(255, 255, 255, 0.07)",
+    borderStrong: "rgba(255, 255, 255, 0.12)",
+    separator: "rgba(255, 255, 255, 0.05)",
+    text: "#E6EDF7",
+    textMuted: "#93A1B8",
+    textSubtle: "#6C7A95",
+    primary: FORD_BLUE_DARK_MODE,
+    primaryDeep: FORD_BLUE_DARK_MODE_DEEP,
+    primaryText: "#FFFFFF",
+    primarySoft: "rgba(91, 141, 239, 0.16)",
+    success: "#2DB67B",
+    successSoft: "rgba(45, 182, 123, 0.16)",
+    warning: "#E3A93C",
+    warningSoft: "rgba(227, 169, 60, 0.16)",
+    error: "#E5484D",
+    errorSoft: "rgba(229, 72, 77, 0.16)",
+    critical: "#FF5463",
+    overlay: "rgba(0, 0, 0, 0.6)",
+    tabBar: "rgba(11, 18, 32, 0.85)",
+    inputBg: "#121A2B",
+  },
+};
+
+export const fontFamily = {
+  regular: "System",
+  medium: "System",
+  semibold: "System",
+  bold: "System",
+  extrabold: "System",
+} as const;
+
+// Weight tokens — paired with fontFamily.System on RN to get bold variants
+// without bundling custom fonts. When we ship Manrope/Inter later, swap families.
+// Pesos: enquanto nao ha fonte custom, usa system + fontWeight numerico.
+export const fontWeight = {
+  regular: "400",
+  medium: "500",
+  semibold: "600",
+  bold: "700",
+  extrabold: "800",
+} as const;
+
+export const fontSize = {
+  xs: 10,
+  sm: 11,
+  md: 13,
+  base: 14,
+  lg: 16,
+  xl: 18,
+  "2xl": 22,
+  "3xl": 28,
+  "4xl": 32,
+  "5xl": 48,
+  "6xl": 72,
 } as const;
 
 export const spacing = {
@@ -22,26 +136,218 @@ export const spacing = {
   sm: 8,
   md: 12,
   lg: 16,
-  xl: 24,
-  xxl: 32,
+  xl: 20,
+  "2xl": 24,
+  "3xl": 32,
+  "4xl": 40,
+  "5xl": 48,
+  "6xl": 64,
 } as const;
 
 export const radius = {
-  sm: 6,
-  md: 10,
-  lg: 14,
+  sm: 8,
+  md: 12,
+  lg: 16,
   xl: 20,
-  pill: 999,
+  "2xl": 24,
+  "3xl": 28,
+  pill: 9999,
+  full: 9999,
 } as const;
 
+export const letterSpacing = {
+  tight: 0,
+  normal: 1,
+  wide: 2,
+  wider: 3,
+  widest: 4,
+  ultra: 6,
+} as const;
+
+// Elevation pra light: sombras reais (iOS shadow* + Android elevation).
+// Hierarquia visual depende da luz vinda de cima.
+export const elevationLight = {
+  none: {
+    shadowColor: "transparent",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0,
+    shadowRadius: 0,
+    elevation: 0,
+  },
+  sm: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.04,
+    shadowRadius: 4,
+    elevation: 1,
+  },
+  md: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  lg: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.1,
+    shadowRadius: 16,
+    elevation: 4,
+  },
+  primary: {
+    shadowColor: FORD_BLUE,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.16,
+    shadowRadius: 12,
+    elevation: 3,
+  },
+} as const;
+
+// Elevation pra dark: zero sombra. Hierarquia via top-highlight (borda superior
+// clarinha). Estetica Vercel/Cursor — sombras em fundo escuro viram manchas.
+export const elevationDark = {
+  none: {},
+  sm: { borderTopColor: "rgba(255,255,255,0.04)", borderTopWidth: 1 },
+  md: { borderTopColor: "rgba(255,255,255,0.06)", borderTopWidth: 1 },
+  lg: { borderTopColor: "rgba(255,255,255,0.08)", borderTopWidth: 1 },
+  primary: { borderTopColor: "rgba(255,255,255,0.10)", borderTopWidth: 1 },
+} as const;
+
+export type Elevation = typeof elevationLight | typeof elevationDark;
+
+// Typography helpers que combinam size + weight + lineHeight em um objeto
+// pronto pra spread. Substitui o `typography.h1` antigo, agora tema-aware
+// no consumer (cor vem de useTheme()).
+// Helpers de tipografia: spread direto no style.
 export const typography = {
-  h1: { fontSize: 28, fontWeight: "700" as const, lineHeight: 34 },
-  h2: { fontSize: 22, fontWeight: "700" as const, lineHeight: 28 },
-  h3: { fontSize: 18, fontWeight: "600" as const, lineHeight: 24 },
-  body: { fontSize: 15, fontWeight: "400" as const, lineHeight: 22 },
-  caption: { fontSize: 13, fontWeight: "400" as const, lineHeight: 18 },
-  label: { fontSize: 12, fontWeight: "600" as const, letterSpacing: 0.5 },
+  h1: { fontSize: fontSize["3xl"], fontWeight: fontWeight.extrabold, lineHeight: 34 },
+  h2: { fontSize: fontSize["2xl"], fontWeight: fontWeight.bold, lineHeight: 28 },
+  h3: { fontSize: fontSize.xl, fontWeight: fontWeight.semibold, lineHeight: 24 },
+  body: { fontSize: fontSize.lg, fontWeight: fontWeight.regular, lineHeight: 22 },
+  caption: { fontSize: fontSize.md, fontWeight: fontWeight.regular, lineHeight: 18 },
+  label: { fontSize: fontSize.sm, fontWeight: fontWeight.semibold, letterSpacing: 0.5 },
 } as const;
 
-export type ColorToken = keyof typeof colors;
+// Status palette: estados de lead (mapeia 1:1 com api Lead.status).
+// Domain-specific, mas tema-agnostic — cores funcionam em light e dark.
+export type LeadStatusKey =
+  | "new"
+  | "assigned"
+  | "contacted"
+  | "converted"
+  | "lost"
+  | "expired";
+
+export type StatusPaletteEntry = {
+  labelKey: string;
+  color: string;
+  bg: string;
+  border: string;
+};
+
+export const leadStatusPalette: Record<LeadStatusKey, StatusPaletteEntry> = {
+  new: {
+    labelKey: "status.new",
+    color: "#5B8DEF",
+    bg: "rgba(91, 141, 239, 0.14)",
+    border: "rgba(91, 141, 239, 0.40)",
+  },
+  assigned: {
+    labelKey: "status.assigned",
+    color: "#A855F7",
+    bg: "rgba(168, 85, 247, 0.14)",
+    border: "rgba(168, 85, 247, 0.40)",
+  },
+  contacted: {
+    labelKey: "status.contacted",
+    color: "#F59E0B",
+    bg: "rgba(245, 158, 11, 0.14)",
+    border: "rgba(245, 158, 11, 0.40)",
+  },
+  converted: {
+    labelKey: "status.converted",
+    color: "#10B981",
+    bg: "rgba(16, 185, 129, 0.16)",
+    border: "rgba(16, 185, 129, 0.45)",
+  },
+  lost: {
+    labelKey: "status.lost",
+    color: "#6B7280",
+    bg: "rgba(107, 114, 128, 0.14)",
+    border: "rgba(107, 114, 128, 0.35)",
+  },
+  expired: {
+    labelKey: "status.expired",
+    color: "#9CA3AF",
+    bg: "rgba(156, 163, 175, 0.12)",
+    border: "rgba(156, 163, 175, 0.30)",
+  },
+};
+
+// Priority palette: mapeia api Lead.priority. Critical chama atencao maxima.
+export type LeadPriorityKey = "low" | "medium" | "high" | "critical";
+
+export const leadPriorityPalette: Record<LeadPriorityKey, StatusPaletteEntry> = {
+  low: {
+    labelKey: "priority.low",
+    color: "#6B7280",
+    bg: "rgba(107, 114, 128, 0.12)",
+    border: "rgba(107, 114, 128, 0.30)",
+  },
+  medium: {
+    labelKey: "priority.medium",
+    color: "#F59E0B",
+    bg: "rgba(245, 158, 11, 0.14)",
+    border: "rgba(245, 158, 11, 0.40)",
+  },
+  high: {
+    labelKey: "priority.high",
+    color: FORD_BLUE_DARK_MODE,
+    bg: "rgba(91, 141, 239, 0.16)",
+    border: "rgba(91, 141, 239, 0.45)",
+  },
+  critical: {
+    labelKey: "priority.critical",
+    color: "#FF5463",
+    bg: "rgba(255, 84, 99, 0.16)",
+    border: "rgba(255, 84, 99, 0.50)",
+  },
+};
+
+// Churn segment palette: mapeia segment do ChurnScore.
+export type ChurnSegmentKey = "fiel" | "abandono" | "esquecido" | "economico";
+
+export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = {
+  fiel: {
+    labelKey: "segment.fiel",
+    color: "#10B981",
+    bg: "rgba(16, 185, 129, 0.14)",
+    border: "rgba(16, 185, 129, 0.40)",
+  },
+  abandono: {
+    labelKey: "segment.abandono",
+    color: "#FF5463",
+    bg: "rgba(255, 84, 99, 0.14)",
+    border: "rgba(255, 84, 99, 0.40)",
+  },
+  esquecido: {
+    labelKey: "segment.esquecido",
+    color: "#F59E0B",
+    bg: "rgba(245, 158, 11, 0.14)",
+    border: "rgba(245, 158, 11, 0.40)",
+  },
+  economico: {
+    labelKey: "segment.economico",
+    color: "#A855F7",
+    bg: "rgba(168, 85, 247, 0.14)",
+    border: "rgba(168, 85, 247, 0.40)",
+  },
+};
+
+// Tokens legados — mantidos para callers ainda nao migrados. Vao sumir
+// conforme as telas adotam useTheme(). NAO usar em codigo novo.
+// Legacy tokens: nao usar em codigo novo. Migrar para useTheme().
+export const colors = palette.dark;
+export type ColorToken = keyof ThemeColors;
 export type SpacingToken = keyof typeof spacing;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,45 @@
+// Pure validation functions. Return ValidationError with an i18n key (and
+// optional interpolation vars) rather than raw strings — callers translate
+// at render time via t(error.key, error.vars).
+// Validacoes puras — retornam chave i18n, nao string traduzida.
+
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const PASSWORD_MIN_LENGTH = 6;
+export const NAME_MIN_LENGTH = 2;
+
+export type ValidationError = {
+  key: string;
+  vars?: Record<string, string | number>;
+};
+
+export type ValidationResult = ValidationError | undefined;
+
+export function validateEmail(email: string): ValidationResult {
+  const trimmed = email.trim();
+  if (!trimmed) return { key: "validation.email_required" };
+  if (!EMAIL_REGEX.test(trimmed)) return { key: "validation.email_invalid" };
+  return undefined;
+}
+
+export function validatePassword(password: string): ValidationResult {
+  if (!password) return { key: "validation.password_required" };
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return {
+      key: "validation.password_too_short",
+      vars: { count: PASSWORD_MIN_LENGTH },
+    };
+  }
+  return undefined;
+}
+
+export function validateRequired(value: string, fieldKey: string): ValidationResult {
+  if (!value.trim()) return { key: "validation.required", vars: { field: fieldKey } };
+  return undefined;
+}
+
+export function validateName(name: string): ValidationResult {
+  const trimmed = name.trim();
+  if (!trimmed) return { key: "validation.name_required" };
+  if (trimmed.length < NAME_MIN_LENGTH) return { key: "validation.name_short" };
+  return undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@expo/metro-runtime": "~55.0.9",
+        "@expo/vector-icons": "^15.0.2",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@supabase/supabase-js": "^2.45.0",
         "expo": "^55.0.15",
         "expo-constants": "~55.0.14",
+        "expo-haptics": "~55.0.14",
         "expo-linking": "~55.0.13",
         "expo-router": "~55.0.12",
         "expo-secure-store": "~55.0.13",
@@ -1865,6 +1868,17 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
     },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
@@ -2267,6 +2281,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -4470,6 +4496,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-haptics": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-55.0.14.tgz",
+      "integrity": "sha512-KjDItBsA9mi1f5nRwf8g1wOdfEcLHwvEdt5Jl1sMCDETR/homcGOl+F3QIiPOl/PRlbGVieQsjTtF4DGtHOj6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-image": {
       "version": "55.0.8",
       "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-55.0.8.tgz",
@@ -5003,17 +5038,6 @@
         "expo": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
-      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/accepts": {
@@ -5712,6 +5736,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-wsl": {
@@ -6446,6 +6479,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~55.0.9",
+    "@expo/vector-icons": "^15.0.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@supabase/supabase-js": "^2.45.0",
     "expo": "^55.0.15",
     "expo-constants": "~55.0.14",
+    "expo-haptics": "~55.0.14",
     "expo-linking": "~55.0.13",
     "expo-router": "~55.0.12",
     "expo-secure-store": "~55.0.13",


### PR DESCRIPTION
## Summary

Foundation pass for visual quality. Establishes the theme + UI primitives the rest of the design polish work depends on.

- Semantic theme tokens (light + dark) with `useColorScheme()` tracking and persisted manual overrides via AsyncStorage
- `ThemeProvider` with a 320ms cross-fade transition when the mode flips
- 6 new UI primitives styled through the new tokens: `Input`, `Toast`, `ProfileAvatar`, `LoadingScreen`, `EmptyState`, `Skeleton`
- Animation hooks (`useShake`, `useFadeIn`), `haptics` wrapper, validation helpers, central `storage-keys`
- Every screen and existing component migrated to consume colors via `useTheme()`
- Login refactor: inline field validation, shake animation, haptic feedback on error/success
- Profile screen: avatar with initials fallback, theme toggle with `selection` haptic, follow-system link

Sprint 1 does not require mobile delivery; this is groundwork that lets feature work (profile photo, language picker, onboarding, TanStack Query persistence) land cleanly in subsequent PRs.

## What changed

| Layer | Files | Change |
| --- | --- | --- |
| Theme | `lib/theme.ts` | Rewritten with dual palettes, semantic tokens, status/priority/churn palettes, theme-aware elevation |
| Context | `context/ThemeContext.tsx` (new) | Provider, cross-fade, persistence, `resetToSystem` |
| Components | `components/ui/{Input,Toast,ProfileAvatar,LoadingScreen,EmptyState,Skeleton}.tsx` (new) | Set of primitives consuming `useTheme()` |
| Hooks | `hooks/{useShake,useFadeIn}.ts` (new) | Animation primitives |
| Lib | `lib/{haptics,storage-keys,validation}.ts` (new) | Helpers |
| Screens | `app/_layout.tsx`, `app/(tabs)/*`, `app/login.tsx`, `app/lead/[id].tsx` | Migrated to `useTheme()`, EmptyState plugged into lists, login refactored |
| Components | `Button.tsx`, `Card.tsx`, `Badge.tsx`, `IntroVideo.tsx`, `LeadCard.tsx` | Migrated to `useTheme()` |
| i18n | `i18n/{en,pt-BR}.json` | New keys under `auth`, `profile`, `loading`, `home.empty`, `validation` |
| Deps | `package.json`, `package-lock.json` | +`@react-native-async-storage/async-storage`, `expo-haptics`, `@expo/vector-icons` |

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [ ] `npm run start` boots without runtime errors
- [ ] Login screen: empty fields show inline errors, shake on submit, haptic error
- [ ] Login screen: invalid credentials show server error box, valid login navigates and triggers haptic success
- [ ] Profile screen: avatar renders initials from email when no photo, theme switch toggles between light and dark with cross-fade animation
- [ ] Profile screen: toggling shows "Manual override active"; tapping "Voltar a seguir o sistema" reverts to following `useColorScheme()`
- [ ] Theme preference persists across app restarts
- [ ] Home and Leads empty states render `EmptyState` component instead of bare text
- [ ] LeadCard renders the same as before (visual regression check)
- [ ] Verify dark-mode primary `#5B8DEF` reads well against `#0B1220` backgrounds; adjust `FORD_BLUE_DARK_MODE` in `lib/theme.ts` if not

## Out of scope (deferred to next PRs)

- Profile photo upload (camera + library + Supabase Storage) — phase 4 of the port plan
- Language picker modal + `LocaleContext` wrapping `react-i18next`
- Marketing onboarding (3-slide intro) and dealer-selection onboarding
- TanStack Query with persistence on the leads list

🤖 Generated with [Claude Code](https://claude.com/claude-code)