### PR TITLE
feat: locale picker with persisted user override

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -15,13 +15,16 @@ import { router } from "expo-router";
 
 import { Button } from "@/components/ui/Button";
 import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import { LocalePicker } from "@/components/ui/LocalePicker";
 import { ProfileAvatar } from "@/components/ui/ProfileAvatar";
 import { Toast, type ToastVariant } from "@/components/ui/Toast";
+import { useLocale } from "@/context/LocaleContext";
 import { useTheme } from "@/context/ThemeContext";
 import { signOut } from "@/lib/auth";
 import { deleteAvatar, uploadAvatar } from "@/lib/avatar-upload";
 import { haptic } from "@/lib/haptics";
 import { pickFromCamera, pickFromLibrary, type PickedImage } from "@/lib/image-picker";
+import { LOCALE_LABEL, LOCALE_SHORT } from "@/lib/locale";
 import { fetchMyProfile, updateMyProfile, type Profile } from "@/lib/profile";
 import { supabase } from "@/lib/supabase";
 import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
@@ -34,10 +37,12 @@ type ProfileState = {
 export default function ProfileScreen() {
   const { t } = useTranslation();
   const { colors, mode, toggleTheme, isOverridden, resetToSystem } = useTheme();
+  const { locale } = useLocale();
   const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const [state, setState] = useState<ProfileState | null>(null);
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const [localePickerOpen, setLocalePickerOpen] = useState(false);
   const [toast, setToast] = useState<{
     visible: boolean;
     message: string;
@@ -120,6 +125,11 @@ export default function ProfileScreen() {
   function onResetToSystem() {
     haptic.light();
     resetToSystem();
+  }
+
+  function onOpenLocalePicker() {
+    haptic.light();
+    setLocalePickerOpen(true);
   }
 
   if (!state) {
@@ -240,6 +250,27 @@ export default function ProfileScreen() {
           </Pressable>
         ) : null}
 
+        <Text style={styles.sectionTitle}>{t("profile.language")}</Text>
+        <Pressable
+          onPress={onOpenLocalePicker}
+          style={({ pressed }) => [styles.localeRow, pressed && styles.pressedSoft]}
+          accessibilityRole="button"
+          accessibilityLabel={`${t("profile.language")}: ${LOCALE_LABEL[locale]}`}
+        >
+          <View style={styles.localeLeft}>
+            <View style={styles.localeIconWrap}>
+              <Ionicons name="globe-outline" size={18} color={colors.primary} />
+            </View>
+            <View style={styles.localeTextos}>
+              <Text style={styles.localeLabel}>{t("profile.language")}</Text>
+              <Text style={styles.localeValue}>
+                {LOCALE_LABEL[locale]} · {LOCALE_SHORT[locale]}
+              </Text>
+            </View>
+          </View>
+          <Ionicons name="chevron-down" size={16} color={colors.textSubtle} />
+        </Pressable>
+
         <Text style={styles.sectionTitle}>{t("profile.account")}</Text>
         <View style={styles.actionsCard}>
           <Button label={t("profile.sign_out")} variant="secondary" onPress={onSignOut} />
@@ -251,6 +282,11 @@ export default function ProfileScreen() {
         variant={toast.variant}
         visible={toast.visible}
         onHide={() => setToast((p) => ({ ...p, visible: false }))}
+      />
+
+      <LocalePicker
+        visible={localePickerOpen}
+        onClose={() => setLocalePickerOpen(false)}
       />
     </View>
   );
@@ -445,6 +481,44 @@ function createStyles(c: ThemeColors) {
       ...typography.caption,
       color: c.primary,
       fontWeight: "600",
+    },
+    localeRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: spacing.md,
+      marginHorizontal: spacing.xl,
+      marginBottom: spacing.lg,
+      backgroundColor: c.surface,
+      borderRadius: radius.lg,
+      padding: spacing.lg,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    localeLeft: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.md,
+    },
+    localeIconWrap: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: c.primarySoft,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    localeTextos: { flex: 1 },
+    localeLabel: {
+      ...typography.caption,
+      color: c.textMuted,
+    },
+    localeValue: {
+      ...typography.body,
+      fontWeight: "700",
+      color: c.text,
+      marginTop: 2,
     },
     actionsCard: {
       marginHorizontal: spacing.xl,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 
 import "@/i18n";
 import { IntroVideo } from "@/components/ui/IntroVideo";
+import { LocaleProvider } from "@/context/LocaleContext";
 import { ThemeProvider, useTheme } from "@/context/ThemeContext";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
@@ -13,7 +14,9 @@ export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        <RootStack />
+        <LocaleProvider>
+          <RootStack />
+        </LocaleProvider>
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/components/ui/LocalePicker.tsx
+++ b/components/ui/LocalePicker.tsx
@@ -1,0 +1,143 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useMemo } from "react";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+
+import { useLocale } from "@/context/LocaleContext";
+import { haptic } from "@/lib/haptics";
+import { LOCALE_LABEL, LOCALE_SHORT, type Locale } from "@/lib/locale";
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+
+export interface LocalePickerProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function LocalePicker({ visible, onClose }: LocalePickerProps) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { locale, locales, setLocale } = useLocale();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  function onSelect(target: Locale) {
+    if (target !== locale) haptic.selection();
+    setLocale(target);
+    onClose();
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable
+        style={styles.backdrop}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel={t("cta.close")}
+      >
+        <Pressable
+          style={[styles.card, { paddingBottom: insets.bottom + spacing.md }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={styles.handle} />
+          <View style={styles.header}>
+            <Ionicons name="globe-outline" size={20} color={colors.primary} />
+            <Text style={styles.title}>{t("profile.language")}</Text>
+          </View>
+          {locales.map((loc, idx) => {
+            const active = locale === loc;
+            return (
+              <View key={loc}>
+                {idx > 0 ? <View style={styles.divider} /> : null}
+                <Pressable
+                  onPress={() => onSelect(loc)}
+                  style={({ pressed }) => [
+                    styles.option,
+                    pressed && styles.pressed,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={LOCALE_LABEL[loc]}
+                  accessibilityState={{ selected: active }}
+                >
+                  <View style={styles.optionTexts}>
+                    <Text style={styles.optionName}>{LOCALE_LABEL[loc]}</Text>
+                    <Text style={styles.optionShort}>{LOCALE_SHORT[loc]}</Text>
+                  </View>
+                  {active ? (
+                    <Ionicons name="checkmark" size={20} color={colors.primary} />
+                  ) : null}
+                </Pressable>
+              </View>
+            );
+          })}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: c.overlay,
+      justifyContent: "flex-end",
+    },
+    card: {
+      backgroundColor: c.surface,
+      borderTopLeftRadius: radius["2xl"],
+      borderTopRightRadius: radius["2xl"],
+      paddingHorizontal: spacing.xl,
+      paddingTop: spacing.md,
+    },
+    handle: {
+      alignSelf: "center",
+      width: 40,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: c.borderStrong,
+      marginBottom: spacing.lg,
+    },
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.sm,
+      paddingBottom: spacing.md,
+    },
+    title: {
+      ...typography.h3,
+      color: c.text,
+    },
+    option: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingVertical: spacing.md + 2,
+    },
+    optionTexts: { flex: 1 },
+    optionName: {
+      ...typography.body,
+      fontWeight: "600",
+      color: c.text,
+    },
+    optionShort: {
+      ...typography.caption,
+      color: c.textMuted,
+      marginTop: 2,
+      letterSpacing: 1,
+    },
+    divider: {
+      height: 1,
+      backgroundColor: c.separator,
+    },
+    pressed: {
+      opacity: 0.7,
+    },
+  });
+}

--- a/context/LocaleContext.tsx
+++ b/context/LocaleContext.tsx
@@ -1,0 +1,115 @@
+// LocaleProvider: thin layer over react-i18next. Owns the persisted user
+// override in AsyncStorage and keeps i18next.language in sync. When no override
+// is stored, the locale follows the device locale detected at boot.
+// Provider de locale: persiste override do usuario, mantem i18next em sincronia.
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import i18n, { detectDeviceLocale } from "@/i18n";
+import { STORAGE_KEYS } from "@/lib/storage-keys";
+import { isLocale, LOCALES, type Locale } from "@/lib/locale";
+
+type LocaleContextValue = {
+  locale: Locale;
+  /** Supported locales for picker UIs. */
+  locales: readonly Locale[];
+  setLocale: (l: Locale) => void;
+  isHydrated: boolean;
+  /** true when a user override is persisted; false when following the device. */
+  isOverridden: boolean;
+  /** Drop the override and follow the device locale again. */
+  resetToSystem: () => void;
+};
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
+
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  // i18n already exposes the active language reactively via useTranslation —
+  // we read i18n.language through it so any setLocale call re-renders consumers.
+  const { i18n: i18nInstance } = useTranslation();
+  const activeLocale: Locale = isLocale(i18nInstance.language)
+    ? i18nInstance.language
+    : detectDeviceLocale();
+
+  const [override, setOverride] = useState<Locale | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  // Boot: apply persisted override on top of the device-detected locale.
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEYS.LOCALE)
+      .then((stored: string | null) => {
+        if (cancelled) return;
+        if (isLocale(stored)) {
+          setOverride(stored);
+          if (i18n.language !== stored) void i18n.changeLanguage(stored);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persistOverride = useCallback((next: Locale | null) => {
+    if (next === null) {
+      AsyncStorage.removeItem(STORAGE_KEYS.LOCALE).catch(() => {
+        // storage failures should not block UX
+      });
+    } else {
+      AsyncStorage.setItem(STORAGE_KEYS.LOCALE, next).catch(() => {
+        // storage failures should not block UX
+      });
+    }
+  }, []);
+
+  const setLocale = useCallback(
+    (next: Locale) => {
+      setOverride(next);
+      persistOverride(next);
+      if (i18n.language !== next) void i18n.changeLanguage(next);
+    },
+    [persistOverride],
+  );
+
+  const resetToSystem = useCallback(() => {
+    const device = detectDeviceLocale();
+    setOverride(null);
+    persistOverride(null);
+    if (i18n.language !== device) void i18n.changeLanguage(device);
+  }, [persistOverride]);
+
+  const value = useMemo<LocaleContextValue>(
+    () => ({
+      locale: activeLocale,
+      locales: LOCALES,
+      setLocale,
+      isHydrated,
+      isOverridden: override !== null,
+      resetToSystem,
+    }),
+    [activeLocale, override, isHydrated, setLocale, resetToSystem],
+  );
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale(): LocaleContextValue {
+  const ctx = useContext(LocaleContext);
+  if (!ctx) {
+    throw new Error("useLocale must be used inside <LocaleProvider>");
+  }
+  return ctx;
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -75,6 +75,7 @@
     "theme_auto": "Following system",
     "theme_manual": "Manual override active",
     "follow_system": "Follow system again",
+    "language": "Language",
     "photo": "Photo",
     "change_photo": "Change photo",
     "camera": "Camera",
@@ -84,5 +85,9 @@
     "photo_failed": "Could not upload photo",
     "photo_removed": "Photo removed",
     "photo_remove_failed": "Could not remove photo"
+  },
+  "cta": {
+    "close": "Close",
+    "cancel": "Cancel"
   }
 }

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,21 +1,33 @@
-// i18n bootstrap. Language is detected from the device; falls back to pt-BR.
-// Bootstrap de i18n: detecta do dispositivo, fallback pt-BR.
+// i18n bootstrap. Initial language is detected from the device and mapped to
+// one of our supported locales. LocaleContext is in charge of applying a
+// persisted user override on top of this at app startup.
+// Bootstrap do i18n: locale inicial via device; LocaleContext aplica override
+// persistido depois.
 
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import { NativeModules, Platform } from "react-native";
 
+import { isLocale, type Locale } from "@/lib/locale";
+
 import en from "./en.json";
 import ptBR from "./pt-BR.json";
 
-function detectLocale(): string {
+/** Reads the device locale and maps it onto a supported Locale, defaulting to pt-BR. */
+export function detectDeviceLocale(): Locale {
   try {
     const tag =
       Platform.OS === "ios"
         ? NativeModules.SettingsManager?.settings?.AppleLocale ??
           NativeModules.SettingsManager?.settings?.AppleLanguages?.[0]
         : NativeModules.I18nManager?.localeIdentifier;
-    return typeof tag === "string" ? tag.replace("_", "-") : "pt-BR";
+    if (typeof tag !== "string") return "pt-BR";
+    const normalized = tag.replace("_", "-");
+    if (isLocale(normalized)) return normalized;
+    // Map base language (e.g. "en-US" -> "en", "pt-PT" -> "pt-BR").
+    if (normalized.startsWith("en")) return "en";
+    if (normalized.startsWith("pt")) return "pt-BR";
+    return "pt-BR";
   } catch {
     return "pt-BR";
   }
@@ -26,7 +38,7 @@ void i18n.use(initReactI18next).init({
     en: { translation: en },
     "pt-BR": { translation: ptBR },
   },
-  lng: detectLocale(),
+  lng: detectDeviceLocale(),
   fallbackLng: "pt-BR",
   interpolation: { escapeValue: false },
   compatibilityJSON: "v4",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -79,6 +79,7 @@
     "theme_auto": "Seguindo o sistema",
     "theme_manual": "Override manual ativo",
     "follow_system": "Voltar a seguir o sistema",
+    "language": "Idioma",
     "photo": "Foto",
     "change_photo": "Trocar foto",
     "camera": "Camera",
@@ -88,5 +89,9 @@
     "photo_failed": "Nao foi possivel enviar a foto",
     "photo_removed": "Foto removida",
     "photo_remove_failed": "Nao foi possivel remover a foto"
+  },
+  "cta": {
+    "close": "Fechar",
+    "cancel": "Cancelar"
   }
 }

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -1,0 +1,22 @@
+// Locale metadata. Two supported codes today (BCP-47 tags matching i18n
+// resource keys). Add new entries here and in i18n/<code>.json together.
+// Locales suportados: pt-BR (default) e en.
+
+export type Locale = "pt-BR" | "en";
+
+export const LOCALES: readonly Locale[] = ["pt-BR", "en"] as const;
+
+export const LOCALE_LABEL: Record<Locale, string> = {
+  "pt-BR": "Português (Brasil)",
+  en: "English",
+};
+
+/** Two-letter short code for compact UI (chips, selectors). */
+export const LOCALE_SHORT: Record<Locale, string> = {
+  "pt-BR": "PT",
+  en: "EN",
+};
+
+export function isLocale(value: string | null | undefined): value is Locale {
+  return value === "pt-BR" || value === "en";
+}


### PR DESCRIPTION
## Summary

Adds a thin `LocaleContext` on top of `react-i18next` that owns the persisted user choice in `AsyncStorage` and keeps `i18next.language` in sync. Profile screen gains a "Language" row that opens a bottom-sheet picker.

- `useLocale()` mirrors `useTheme()` API: `{ locale, setLocale, isOverridden, resetToSystem, locales }`
- When no override stored, locale follows device-detected language at boot
- Picking a locale persists it under `@forward:locale`; the override is sticky until cleared
- Two supported locales today: `pt-BR` (default), `en` — adding more is `LOCALES` + `LOCALE_LABEL` + a new JSON
- Bottom-sheet modal styled with overlay backdrop, drag-handle, globe icon, checkmark on active option

**Base: `feat/theme-and-ui-foundation` (PR #10).** This is stacked on top — needs PR #10 merged first, or merge in-order.

## Files

| Type | Path | Purpose |
| --- | --- | --- |
| New | `lib/locale.ts` | Locale type, LOCALES list, labels, `isLocale` guard |
| New | `context/LocaleContext.tsx` | Provider + `useLocale` hook |
| New | `components/ui/LocalePicker.tsx` | Bottom-sheet modal |
| Modified | `i18n/index.ts` | `detectDeviceLocale` typed + maps base languages onto supported locales |
| Modified | `app/_layout.tsx` | `LocaleProvider` mounted inside `ThemeProvider` |
| Modified | `app/(tabs)/profile.tsx` | New "Language" row that triggers the picker |
| Modified | `i18n/{en,pt-BR}.json` | `profile.language` + `cta.{close,cancel}` |

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Open Profile, tap "Language" row → bottom-sheet appears with handle + globe icon + 2 options
- [ ] Selecting a different locale: haptic `selection`, picker closes, every screen text retranslates (tabs, titles, etc.)
- [ ] Selected locale persists across app restarts
- [ ] On a fresh install with device set to English: app boots in `en`
- [ ] On a fresh install with device set to Portuguese: app boots in `pt-BR`
- [ ] On a fresh install with device set to Spanish: app falls back to `pt-BR` (default in `detectDeviceLocale`)

## Out of scope

- Profile photo upload (next PR — requires Supabase Storage bucket + RLS)
- Additional locales (es, etc.) — easy to add later

🤖 Generated with [Claude Code](https://claude.com/claude-code)