### PR TITLE
feat(theme): mono typography, letter-spacing, elevation aliases [Phase 1]

### DIFF
--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -3,6 +3,8 @@
 // useTheme() — never import `palette` directly.
 // Tokens de design: paletas light/dark, espacamento, tipografia, elevacao.
 
+import { Platform } from "react-native";
+
 export type ThemeMode = "light" | "dark";
 
 export type ThemeColors = {
@@ -104,6 +106,11 @@ export const fontFamily = {
   semibold: "System",
   bold: "System",
   extrabold: "System",
+  mono: Platform.select({
+    ios: "Menlo",
+    android: "monospace",
+    default: "ui-monospace",
+  }) as string,
 } as const;
 
 // Weight tokens — paired with fontFamily.System on RN to get bold variants
@@ -214,6 +221,21 @@ export const elevationDark = {
   primary: { borderTopColor: "rgba(255,255,255,0.10)", borderTopWidth: 1 },
 } as const;
 
+// Semantic elevation aliases — usar nas telas em vez de sm/md/lg/primary direto.
+// Card = elemento normal. Sheet = modal/bottom-sheet. Popover = floating action.
+// Aliases semanticos: card / sheet / popover.
+export const elevationAliasLight = {
+  card: elevationLight.sm,
+  sheet: elevationLight.lg,
+  popover: elevationLight.primary,
+} as const;
+
+export const elevationAliasDark = {
+  card: elevationDark.sm,
+  sheet: elevationDark.lg,
+  popover: elevationDark.primary,
+} as const;
+
 export type Elevation = typeof elevationLight | typeof elevationDark;
 
 // Typography helpers que combinam size + weight + lineHeight em um objeto
@@ -221,12 +243,34 @@ export type Elevation = typeof elevationLight | typeof elevationDark;
 // no consumer (cor vem de useTheme()).
 // Helpers de tipografia: spread direto no style.
 export const typography = {
-  h1: { fontSize: fontSize["3xl"], fontWeight: fontWeight.extrabold, lineHeight: 34 },
-  h2: { fontSize: fontSize["2xl"], fontWeight: fontWeight.bold, lineHeight: 28 },
+  h1: {
+    fontSize: fontSize["3xl"],
+    fontWeight: fontWeight.extrabold,
+    lineHeight: 34,
+    letterSpacing: -0.4,
+  },
+  h2: {
+    fontSize: fontSize["2xl"],
+    fontWeight: fontWeight.bold,
+    lineHeight: 28,
+    letterSpacing: -0.3,
+  },
   h3: { fontSize: fontSize.xl, fontWeight: fontWeight.semibold, lineHeight: 24 },
   body: { fontSize: fontSize.lg, fontWeight: fontWeight.regular, lineHeight: 22 },
   caption: { fontSize: fontSize.md, fontWeight: fontWeight.regular, lineHeight: 18 },
   label: { fontSize: fontSize.sm, fontWeight: fontWeight.semibold, letterSpacing: 0.5 },
+  mono: {
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    letterSpacing: 0,
+  },
+  monoSmall: {
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.md,
+    fontWeight: fontWeight.medium,
+    letterSpacing: 0,
+  },
 } as const;
 
 // Status palette: estados de lead (mapeia 1:1 com api Lead.status).


### PR DESCRIPTION
## Summary

Phase 1 do mobile polish (autonomous run). Updates puramente em \`lib/theme.ts\`, sem mudanças de comportamento — apenas tokens novos pra serem consumidos pelas próximas fases.

### Mudanças
- \`fontFamily.mono\` per platform (Menlo iOS, monospace Android, ui-monospace web)
- \`typography.mono\` (lg + semibold) e \`typography.monoSmall\` (md + medium) para R\$, VIN, scores
- \`letterSpacing: -0.4\` em h1 e \`-0.3\` em h2 (síntese do UX-UI guide)
- \`elevationAliasLight/Dark\` com \`card/sheet/popover\` (mais semântico que sm/md/lg)

### Não mudou
- Palettes (\`palette\`, \`leadStatusPalette\`, \`leadPriorityPalette\`, \`churnSegmentPalette\`)
- \`spacing\`, \`radius\`, \`fontSize\`, \`fontWeight\`
- \`elevationLight\` / \`elevationDark\` base entries
- \`h3\` / \`body\` / \`caption\` / \`label\` typography (intactos)

## Test plan
- [x] \`npm run typecheck\` zero erros
- [x] Reviewer subagent (opus, code-reviewer): APPROVED, zero issues
- [x] Tokens novos prontos pra serem consumidos pelos componentes nas próximas fases

Spec ref: [\`docs/superpowers/specs/2026-05-23-mobile-polish-design.md#3-foundation--mudanças-em-libthemets\`](../blob/main/docs/superpowers/specs/2026-05-23-mobile-polish-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)