### PR TITLE
fix(intro): web autoplay bug + 6s fallback [Phase 2]

### DIFF
--- a/components/ui/IntroVideo.tsx
+++ b/components/ui/IntroVideo.tsx
@@ -33,7 +33,10 @@ export function IntroVideo({ onFinished }: IntroVideoProps) {
   const player = useVideoPlayer(INTRO_SOURCE, (p) => {
     p.loop = false;
     p.muted = true;
-    p.play();
+    // play() removed from setup - does not work on web during render phase
+    // (the <video> DOM element isn't mounted yet, so the call iterates an
+    // empty Set). Moved to useEffect below.
+    // play() saiu do setup - no web nao funciona durante render.
   });
 
   // Fade the overlay out, then notify the parent once.
@@ -47,8 +50,23 @@ export function IntroVideo({ onFinished }: IntroVideoProps) {
   }, [onFinished, opacity]);
 
   useEffect(() => {
+    // Native: play() pending until VideoView mounts (handled by impl).
+    // Web: VideoView.web.js requires the <video> in DOM before play().
+    // useEffect runs post-mount, so this works on both platforms.
+    // Nativo retem play() pendente; web exige <video> montado.
+    player.play();
     const sub = player.addListener("playToEnd", finish);
-    return () => sub.remove();
+
+    // Web autoplay can be blocked silently by the browser. After 6s with no
+    // playToEnd event, release the gate so the user is never stuck on intro.
+    // Native always reaches playToEnd well before this timeout fires.
+    // Fallback de 6s pra autoplay bloqueado no web.
+    const blockedTimeout = setTimeout(finish, 6000);
+
+    return () => {
+      sub.remove();
+      clearTimeout(blockedTimeout);
+    };
   }, [player, finish]);
 
   const overlayStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
@@ -62,6 +80,7 @@ export function IntroVideo({ onFinished }: IntroVideoProps) {
           contentFit="cover"
           nativeControls={false}
           allowsPictureInPicture={false}
+          playsInline
         />
       </Pressable>
       <Pressable onPress={finish} hitSlop={12} style={styles.skip} accessibilityRole="button">


### PR DESCRIPTION
## Summary

Fix bug onde o IntroVideo congelava no primeiro frame ao rodar via \`npm run web\`. \`expo-video@55.0.15\` no web requer que \`<video>\` esteja montado no DOM antes de \`play()\` — o callback de \`useVideoPlayer\` roda DURANTE o render, então \`_mountedVideos\` ainda está vazio e o \`play()\` vira no-op silencioso.

### Fix (3 mudanças em \`components/ui/IntroVideo.tsx\`)
1. \`p.play()\` removido do setup callback de \`useVideoPlayer\`
2. \`player.play()\` movido pro \`useEffect\` (post-mount, funciona em ambas plataformas)
3. \`playsInline\` adicionado ao \`<VideoView>\` (alguns engines de browser bloqueiam autoplay muted sem isso)
4. \`setTimeout(finish, 6000)\` adicionado como fallback — se autoplay for bloqueado por qualquer razão, libera o gate em 6s, nunca trava o usuário

### Comportamento por plataforma
- **iOS/Android nativo:** funciona como antes; \`playToEnd\` chega bem antes dos 6s, timeout é limpo
- **Web (autoplay OK):** também funciona; \`playToEnd\` chega antes do timeout
- **Web (autoplay bloqueado):** timeout libera em 6s; \`finished.current\` ref previne double-fire entre listener e timeout

## Test plan
- [x] \`npm run typecheck\` PASS
- [x] Reviewer subagent (opus): APPROVED, zero issues
- [ ] Manual: rodar \`npm run web\` e verificar que o vídeo toca (gate manual de manhã)

🤖 Generated with [Claude Code](https://claude.com/claude-code)