### PR TITLE
feat: shared infra — ScreenHeader, ErrorBanner, LeadCardSkeleton, PhotoButton, relative-time [Phase 3]

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -16,6 +16,7 @@ import { router } from "expo-router";
 import { Button } from "@/components/ui/Button";
 import { LoadingScreen } from "@/components/ui/LoadingScreen";
 import { LocalePicker } from "@/components/ui/LocalePicker";
+import { PhotoButton } from "@/components/ui/PhotoButton";
 import { ProfileAvatar } from "@/components/ui/ProfileAvatar";
 import { Toast, type ToastVariant } from "@/components/ui/Toast";
 import { useLocale } from "@/context/LocaleContext";
@@ -187,16 +188,12 @@ export default function ProfileScreen() {
             label={t("profile.camera")}
             onPress={onPickFromCamera}
             disabled={uploadingPhoto}
-            colors={colors}
-            styles={styles}
           />
           <PhotoButton
             icon="images-outline"
             label={t("profile.gallery")}
             onPress={onPickFromLibrary}
             disabled={uploadingPhoto}
-            colors={colors}
-            styles={styles}
           />
           {profile?.avatar_url ? (
             <PhotoButton
@@ -204,8 +201,6 @@ export default function ProfileScreen() {
               label={t("profile.remove")}
               onPress={onRemovePhoto}
               disabled={uploadingPhoto}
-              colors={colors}
-              styles={styles}
               destructive
             />
           ) : null}
@@ -292,61 +287,6 @@ export default function ProfileScreen() {
   );
 }
 
-type PhotoButtonProps = {
-  icon: keyof typeof import("@expo/vector-icons").Ionicons.glyphMap;
-  label: string;
-  onPress: () => void;
-  disabled: boolean;
-  destructive?: boolean;
-  colors: ThemeColors;
-  styles: ReturnType<typeof createStyles>;
-};
-
-function PhotoButton({
-  icon,
-  label,
-  onPress,
-  disabled,
-  destructive,
-  colors,
-  styles,
-}: PhotoButtonProps) {
-  return (
-    <Pressable
-      onPress={onPress}
-      disabled={disabled}
-      style={({ pressed }) => [
-        styles.photoButton,
-        pressed && styles.pressedSoft,
-        disabled && { opacity: 0.5 },
-      ]}
-      accessibilityRole="button"
-      accessibilityLabel={label}
-    >
-      <View
-        style={[
-          styles.photoIconWrap,
-          destructive ? { backgroundColor: colors.errorSoft } : undefined,
-        ]}
-      >
-        <Ionicons
-          name={icon}
-          size={18}
-          color={destructive ? colors.error : colors.primary}
-        />
-      </View>
-      <Text
-        style={[
-          styles.photoButtonLabel,
-          destructive ? { color: colors.error } : undefined,
-        ]}
-      >
-        {label}
-      </Text>
-    </Pressable>
-  );
-}
-
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
     container: { flex: 1, backgroundColor: c.bg },
@@ -410,29 +350,6 @@ function createStyles(c: ThemeColors) {
       gap: spacing.sm,
       paddingHorizontal: spacing.xl,
       marginBottom: spacing.lg,
-    },
-    photoButton: {
-      flex: 1,
-      backgroundColor: c.surface,
-      borderRadius: radius.lg,
-      paddingVertical: spacing.md + 2,
-      alignItems: "center",
-      gap: spacing.sm,
-      borderWidth: 1,
-      borderColor: c.border,
-    },
-    photoIconWrap: {
-      width: 36,
-      height: 36,
-      borderRadius: 18,
-      backgroundColor: c.primarySoft,
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    photoButtonLabel: {
-      ...typography.caption,
-      fontWeight: "600",
-      color: c.text,
     },
     themeCard: {
       flexDirection: "row",

--- a/components/domain/LeadCardSkeleton.tsx
+++ b/components/domain/LeadCardSkeleton.tsx
@@ -1,0 +1,59 @@
+// Skeleton placeholder matching the shape of the rewritten LeadCard.
+// Used during initial load on Home and Leads. Render 3-5 stacked
+// instances inside the list while data is fetching.
+// Esqueleto do LeadCard novo: usado no loading inicial.
+
+import { useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+
+import { Card } from "@/components/ui/Card";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, type ThemeColors } from "@/lib/theme";
+
+export function LeadCardSkeleton() {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  return (
+    <Card style={styles.card}>
+      <View style={styles.leftStripe} />
+      <View style={styles.body}>
+        <View style={styles.row}>
+          <Skeleton width={72} height={18} borderRadius={radius.sm} />
+          <Skeleton width={56} height={14} borderRadius={radius.sm} />
+        </View>
+        <Skeleton width="80%" height={16} borderRadius={radius.sm} />
+        <Skeleton width="60%" height={14} borderRadius={radius.sm} />
+        <View style={styles.row}>
+          <Skeleton width={48} height={14} borderRadius={radius.sm} />
+          <Skeleton width={72} height={16} borderRadius={radius.sm} />
+        </View>
+      </View>
+    </Card>
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    card: {
+      flexDirection: "row",
+      padding: 0,
+      overflow: "hidden",
+    },
+    leftStripe: {
+      width: 3,
+      backgroundColor: c.border,
+    },
+    body: {
+      flex: 1,
+      padding: spacing.lg,
+      gap: spacing.sm,
+    },
+    row: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    },
+  });
+}

--- a/components/ui/ErrorBanner.tsx
+++ b/components/ui/ErrorBanner.tsx
@@ -1,0 +1,86 @@
+// Inline error banner with optional retry action. Replaces the <Text style={error}>
+// pattern in Home, Leads, LeadDetail. Always renders an icon for scannability;
+// retry button only renders if onRetry is provided.
+// Banner inline de erro: icon + mensagem + retry opcional.
+
+import { Ionicons } from "@expo/vector-icons";
+import { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useTranslation } from "react-i18next";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { haptic } from "@/lib/haptics";
+
+export interface ErrorBannerProps {
+  message: string;
+  onRetry?: () => void;
+  /** Override the default retry label. Pass an i18n key if you want a non-default label. */
+  retryLabel?: string;
+}
+
+export function ErrorBanner({ message, onRetry, retryLabel }: ErrorBannerProps) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  return (
+    <View style={styles.container}>
+      <Ionicons name="alert-circle-outline" size={20} color={colors.error} />
+      <Text style={styles.message} numberOfLines={3}>
+        {message}
+      </Text>
+      {onRetry ? (
+        <Pressable
+          onPress={() => {
+            haptic.light();
+            onRetry();
+          }}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={retryLabel ?? t("common.retry")}
+          style={({ pressed }) => [styles.retry, pressed && { opacity: 0.7 }]}
+        >
+          <Text style={styles.retryLabel}>{retryLabel ?? t("common.retry")}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.md,
+      backgroundColor: c.errorSoft,
+      borderColor: c.error,
+      borderWidth: 1,
+      borderRadius: radius.md,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.lg,
+      marginHorizontal: spacing.xl,
+      marginBottom: spacing.md,
+    },
+    message: {
+      flex: 1,
+      ...typography.caption,
+      color: c.text,
+      fontWeight: "600",
+    },
+    retry: {
+      paddingVertical: spacing.xs,
+      paddingHorizontal: spacing.sm,
+      borderRadius: radius.sm,
+      backgroundColor: c.surface,
+      borderWidth: 1,
+      borderColor: c.error,
+    },
+    retryLabel: {
+      ...typography.caption,
+      fontWeight: "700",
+      color: c.error,
+    },
+  });
+}

--- a/components/ui/PhotoButton.tsx
+++ b/components/ui/PhotoButton.tsx
@@ -1,0 +1,94 @@
+// Photo source button (Camera / Gallery / Remove). Square card with icon
+// circle + label. Extracted from profile.tsx where it lived as an inline
+// subcomponent. Destructive variant flips colors to error tones.
+// Extraido do profile.tsx pra reuso e clareza.
+
+import { Ionicons } from "@expo/vector-icons";
+import { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+
+export interface PhotoButtonProps {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+}
+
+export function PhotoButton({
+  icon,
+  label,
+  onPress,
+  disabled,
+  destructive,
+}: PhotoButtonProps) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.button,
+        pressed && styles.pressed,
+        disabled && { opacity: 0.5 },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+    >
+      <View
+        style={[
+          styles.iconWrap,
+          destructive ? { backgroundColor: colors.errorSoft } : undefined,
+        ]}
+      >
+        <Ionicons
+          name={icon}
+          size={18}
+          color={destructive ? colors.error : colors.primary}
+        />
+      </View>
+      <Text
+        style={[
+          styles.label,
+          destructive ? { color: colors.error } : undefined,
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    button: {
+      flex: 1,
+      backgroundColor: c.surface,
+      borderRadius: radius.lg,
+      paddingVertical: spacing.md + 2,
+      alignItems: "center",
+      gap: spacing.sm,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    iconWrap: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: c.primarySoft,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    label: {
+      ...typography.caption,
+      fontWeight: "600",
+      color: c.text,
+    },
+    pressed: { opacity: 0.7 },
+  });
+}

--- a/components/ui/ScreenHeader.tsx
+++ b/components/ui/ScreenHeader.tsx
@@ -1,0 +1,66 @@
+// Standard header for tab screens. Replaces the ad-hoc <View><Text/></View>
+// pattern repeated across (tabs)/index, leads, profile. Title is h1, optional
+// subtitle is body textMuted, optional trailing slot is right-aligned for
+// actions like filter / refresh / count.
+// Header padronizado das tabs. Substitui o markup inline duplicado.
+
+import { useMemo, type ReactNode } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "@/context/ThemeContext";
+import { spacing, typography, type ThemeColors } from "@/lib/theme";
+
+export interface ScreenHeaderProps {
+  title: string;
+  subtitle?: string;
+  trailing?: ReactNode;
+}
+
+export function ScreenHeader({ title, subtitle, trailing }: ScreenHeaderProps) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.text}>
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text style={styles.subtitle} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+      {trailing ? <View style={styles.trailing}>{trailing}</View> : null}
+    </View>
+  );
+}
+
+function createStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flexDirection: "row",
+      alignItems: "flex-end",
+      justifyContent: "space-between",
+      gap: spacing.md,
+      paddingHorizontal: spacing.xl,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.lg,
+    },
+    text: { flex: 1, gap: spacing.xs },
+    title: {
+      ...typography.h1,
+      color: c.text,
+    },
+    subtitle: {
+      ...typography.body,
+      color: c.textMuted,
+    },
+    trailing: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.sm,
+    },
+  });
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,5 +1,9 @@
 {
   "app": { "name": "ForwardService" },
+  "common": {
+    "retry": "Try again",
+    "coming_soon": "Coming soon"
+  },
   "intro": { "skip": "Skip" },
   "auth": {
     "sign_in": "Sign in",
@@ -89,5 +93,12 @@
   "cta": {
     "close": "Close",
     "cancel": "Cancel"
+  },
+  "time": {
+    "now": "now",
+    "minutes_ago": "{{count}}m ago",
+    "hours_ago": "{{count}}h ago",
+    "days_ago": "{{count}} day ago",
+    "days_ago_plural": "{{count}} days ago"
   }
 }

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -2,6 +2,10 @@
   "app": {
     "name": "ForwardService"
   },
+  "common": {
+    "retry": "Tentar de novo",
+    "coming_soon": "Em breve"
+  },
   "intro": {
     "skip": "Pular"
   },
@@ -93,5 +97,12 @@
   "cta": {
     "close": "Fechar",
     "cancel": "Cancelar"
+  },
+  "time": {
+    "now": "agora",
+    "minutes_ago": "há {{count}} min",
+    "hours_ago": "há {{count}}h",
+    "days_ago": "há {{count}} dia",
+    "days_ago_plural": "há {{count}} dias"
   }
 }

--- a/lib/relative-time.ts
+++ b/lib/relative-time.ts
@@ -1,0 +1,61 @@
+// Relative time formatter — "agora", "ha 5 min", "ha 3h", "ha 2 dias",
+// then falls back to DD/MM after 7 days. Locale-agnostic: takes the
+// TFunction from react-i18next, so caller controls translation.
+// Formatador relativo: i18n-aware via TFunction passada do caller.
+
+import type { TFunction } from "i18next";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+/**
+ * Format an ISO timestamp as a short relative label.
+ * - < 60s: "now"
+ * - < 60min: "5m ago"
+ * - < 24h: "3h ago"
+ * - < 7d: "2 days ago" (plural-aware)
+ * - >= 7d: "DD/MM" (zero-padded)
+ *
+ * @param iso ISO 8601 timestamp string (e.g. Lead.created_at)
+ * @param t react-i18next TFunction, scoped to the "time" namespace
+ * @param now optional "now" timestamp for deterministic testing (defaults to Date.now())
+ */
+export function formatRelativeTime(
+  iso: string,
+  t: TFunction,
+  now: number = Date.now(),
+): string {
+  const target = Date.parse(iso);
+  if (Number.isNaN(target)) return "";
+
+  const diff = Math.max(0, now - target);
+
+  if (diff < MINUTE_MS) return t("time.now");
+
+  if (diff < HOUR_MS) {
+    const count = Math.floor(diff / MINUTE_MS);
+    return t("time.minutes_ago", { count });
+  }
+
+  if (diff < DAY_MS) {
+    const count = Math.floor(diff / HOUR_MS);
+    return t("time.hours_ago", { count });
+  }
+
+  if (diff < WEEK_MS) {
+    const count = Math.floor(diff / DAY_MS);
+    // i18next plural fallback: count=1 hits "time.days_ago", count>1 hits "time.days_ago_plural"
+    // (configured via the *_plural suffix convention from compatibilityJSON: "v4")
+    return count === 1
+      ? t("time.days_ago", { count })
+      : t("time.days_ago_plural", { count });
+  }
+
+  // Older than a week — short date "DD/MM"
+  const d = new Date(target);
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}`;
+}


### PR DESCRIPTION
## Summary

Phase 3 do mobile polish: infra compartilhada que as próximas fases vão consumir. 5 tasks do plano agrupadas porque são todas adições/extrações isoladas.

### Tasks
- **Task 3:** \`lib/relative-time.ts\` — formatador "agora / 5m ago / 3h ago / 2 days ago / DD/MM" com i18n via TFunction; pluralization via i18next *_plural; chaves \`time.*\` em pt-BR + en
- **Task 4:** \`components/ui/ScreenHeader.tsx\` — header padrão pra tabs (title h1 + subtitle? + trailing slot)
- **Task 5:** \`components/ui/ErrorBanner.tsx\` — banner inline com retry opcional; haptic light no retry; chaves \`common.retry\` / \`common.coming_soon\` em pt-BR + en
- **Task 6:** \`components/domain/LeadCardSkeleton.tsx\` — placeholder com a forma do LeadCard novo (stripe + linhas + valor row)
- **Task 7:** \`components/ui/PhotoButton.tsx\` extraído de \`profile.tsx\` (era subcomponente inline, ~50 linhas a menos)

### Mudanças cirúrgicas em \`app/(tabs)/profile.tsx\`
- Import do PhotoButton novo
- Inline def removida (\`type PhotoButtonProps\` + \`function PhotoButton\`)
- 3 call sites simplificados (não passam mais colors/styles)
- 3 styles removidos do \`createStyles\` (\`photoButton\`, \`photoIconWrap\`, \`photoButtonLabel\`)
- \`pressedSoft\` + \`photoButtonsRow\` preservados (usados por outros lugares)

## Test plan
- [x] \`npm run typecheck\` PASS
- [x] Reviewer subagent (opus): APPROVED, zero blockers
- [x] JSON parity verificada: pt-BR + en com mesmos top-level keys
- [x] Imports sanity-checked: Card, Skeleton, ThemeContext, theme, haptics, TFunction (i18next ^23.11.5)

## Próximas fases
- Phase 4: LeadCard rewrite (consome relative-time + LeadCardSkeleton fica utilizado)
- Phase 5: 5 screen refactors (consomem ScreenHeader + ErrorBanner + PhotoButton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)