### PR TITLE
feat(LeadCard): redesign with stripe, chip, mono VIN, status dot, relative time [Phase 4]

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { FlatList, RefreshControl, StyleSheet, Text, View } from "react-native";
+import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
@@ -63,7 +64,12 @@ export default function HomeScreen() {
           />
         ) : null
       }
-      renderItem={({ item }) => <LeadCard lead={item} />}
+      renderItem={({ item }) => (
+        <LeadCard
+          lead={item}
+          onPress={() => router.push({ pathname: "/lead/[id]", params: { id: item.id } })}
+        />
+      )}
       ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
     />
   );

--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { FlatList, StyleSheet, Text, View } from "react-native";
-import { Link } from "expo-router";
+import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
@@ -45,11 +45,10 @@ export default function LeadsScreen() {
         ) : null
       }
       renderItem={({ item }) => (
-        <Link href={{ pathname: "/lead/[id]", params: { id: item.id } }} asChild>
-          <View>
-            <LeadCard lead={item} />
-          </View>
-        </Link>
+        <LeadCard
+          lead={item}
+          onPress={() => router.push({ pathname: "/lead/[id]", params: { id: item.id } })}
+        />
       )}
       ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
     />

--- a/components/domain/LeadCard.tsx
+++ b/components/domain/LeadCard.tsx
@@ -1,52 +1,204 @@
-import React, { useMemo } from "react";
-import { StyleSheet, Text, View } from "react-native";
+// LeadCard — domain component for showing a lead in lists.
+// Layout (left to right):
+//   [3px priority stripe] [body]
+// Body rows:
+//   1. Priority chip (colored, uppercase) on the left + relative time on the right
+//   2. VIN in mono semibold
+//   3. Reason in body textMuted (optional)
+//   4. Status dot + label on the left + expected value (mono, primary color) on the right
+// Pressable wraps the whole thing; haptic light on press; scale 0.99 on press.
+// Card de lead na lista: stripe + chip + VIN mono + razao + status + valor.
+
+import React, { useMemo, useRef } from "react";
+import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 import { Card } from "@/components/ui/Card";
-import { Badge } from "@/components/ui/Badge";
 import { useTheme } from "@/context/ThemeContext";
+import { haptic } from "@/lib/haptics";
 import type { Lead } from "@/lib/api";
-import { spacing, typography, type ColorToken, type ThemeColors } from "@/lib/theme";
+import { formatRelativeTime } from "@/lib/relative-time";
+import {
+  leadPriorityPalette,
+  leadStatusPalette,
+  radius,
+  spacing,
+  typography,
+  type ThemeColors,
+} from "@/lib/theme";
 
-const priorityTone: Record<Lead["priority"], ColorToken> = {
-  low: "textMuted",
-  medium: "warning",
-  high: "primary",
-  critical: "critical",
-};
+export interface LeadCardProps {
+  lead: Lead;
+  onPress?: () => void;
+}
 
-export function LeadCard({ lead }: { lead: Lead }) {
+const SCALE_PRESSED = 0.99;
+
+export function LeadCard({ lead, onPress }: LeadCardProps) {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
+  const scale = useRef(new Animated.Value(1)).current;
 
-  return (
+  const priority = leadPriorityPalette[lead.priority];
+  const status = leadStatusPalette[lead.status];
+  const relativeTime = formatRelativeTime(lead.created_at, t);
+
+  const handlePressIn = () => {
+    if (!onPress) return;
+    Animated.spring(scale, {
+      toValue: SCALE_PRESSED,
+      useNativeDriver: true,
+      speed: 60,
+      bounciness: 0,
+    }).start();
+  };
+  const handlePressOut = () => {
+    if (!onPress) return;
+    Animated.spring(scale, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 60,
+      bounciness: 6,
+    }).start();
+  };
+
+  const cardBody = (
     <Card style={styles.card}>
-      <View style={styles.row}>
-        <Text style={styles.vin}>{lead.vin ?? "—"}</Text>
-        <Badge label={t(`priority.${lead.priority}`)} tone={priorityTone[lead.priority]} />
-      </View>
-      {lead.reason ? <Text style={styles.reason}>{lead.reason}</Text> : null}
-      <View style={styles.row}>
-        <Badge label={t(`status.${lead.status}`)} tone="textMuted" />
-        {lead.expected_value_brl != null ? (
-          <Text style={styles.value}>
-            {new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(
-              lead.expected_value_brl,
-            )}
+      <View style={[styles.stripe, { backgroundColor: priority.color }]} />
+      <View style={styles.body}>
+        <View style={styles.row}>
+          <View style={[styles.chip, { backgroundColor: priority.bg, borderColor: priority.border }]}>
+            <Text style={[styles.chipLabel, { color: priority.color }]} numberOfLines={1}>
+              {t(priority.labelKey)}
+            </Text>
+          </View>
+          {relativeTime ? (
+            <Text style={styles.time} numberOfLines={1}>
+              {relativeTime}
+            </Text>
+          ) : null}
+        </View>
+
+        <Text style={styles.vin} numberOfLines={1}>
+          {lead.vin ?? "—"}
+        </Text>
+
+        {lead.reason ? (
+          <Text style={styles.reason} numberOfLines={2}>
+            {lead.reason}
           </Text>
         ) : null}
+
+        <View style={styles.row}>
+          <View style={styles.statusGroup}>
+            <View style={[styles.dot, { backgroundColor: status.color }]} />
+            <Text style={styles.statusLabel} numberOfLines={1}>
+              {t(status.labelKey)}
+            </Text>
+          </View>
+          {lead.expected_value_brl != null ? (
+            <Text style={styles.value} numberOfLines={1}>
+              {formatBRL(lead.expected_value_brl)}
+            </Text>
+          ) : null}
+        </View>
       </View>
     </Card>
   );
+
+  if (!onPress) return cardBody;
+
+  return (
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <Pressable
+        onPress={() => {
+          haptic.light();
+          onPress();
+        }}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        accessibilityRole="button"
+        accessibilityLabel={`${t(priority.labelKey)} · ${lead.vin ?? ""}`}
+      >
+        {cardBody}
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+function formatBRL(value: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: 0,
+  }).format(value);
 }
 
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    card: { gap: spacing.sm },
-    row: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
-    vin: { ...typography.h3, color: c.text },
-    reason: { ...typography.body, color: c.textMuted },
-    value: { ...typography.body, color: c.text, fontWeight: "600" },
+    card: {
+      flexDirection: "row",
+      padding: 0,
+      overflow: "hidden",
+    },
+    stripe: {
+      width: 3,
+    },
+    body: {
+      flex: 1,
+      padding: spacing.lg,
+      gap: spacing.sm,
+    },
+    row: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      gap: spacing.md,
+    },
+    chip: {
+      paddingHorizontal: spacing.sm + 2,
+      paddingVertical: 2,
+      borderRadius: radius.sm,
+      borderWidth: 1,
+    },
+    chipLabel: {
+      ...typography.label,
+      fontSize: 10,
+      textTransform: "uppercase",
+      letterSpacing: 0.6,
+    },
+    time: {
+      ...typography.caption,
+      color: c.textSubtle,
+    },
+    vin: {
+      ...typography.mono,
+      color: c.text,
+    },
+    reason: {
+      ...typography.body,
+      color: c.textMuted,
+    },
+    statusGroup: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.xs + 2,
+    },
+    dot: {
+      width: 6,
+      height: 6,
+      borderRadius: 3,
+    },
+    statusLabel: {
+      ...typography.caption,
+      color: c.textMuted,
+      fontWeight: "600",
+    },
+    value: {
+      ...typography.mono,
+      color: c.primary,
+      fontWeight: "700",
+    },
   });
 }


### PR DESCRIPTION
## Summary

Rewrite completo do \`components/domain/LeadCard.tsx\` aplicando o Design DNA. É a peça central que as 5 telas (Phase 5) vão usar.

### Visual novo
- **3px stripe colorida à esquerda** (palette por priority: critical vermelho, high azul Ford dark, medium âmbar, low cinza)
- **Chip uppercase** no topo com bg/border/color da priority palette (era Badge monocromática)
- **Tempo relativo** "agora / 5m ago / 3h ago / 2 days ago / DD/MM" no topo direito (via \`formatRelativeTime\` da Phase 3)
- **VIN em mono** (Menlo/monospace) semibold
- **Status como dot 6px colorido + label** (mais discreto que badge)
- **Valor em mono primary** (R\$ 12k, \`maximumFractionDigits: 0\` pra caber bonito no card)
- **Card inteiro é Pressable** com \`haptic.light()\` + scale spring 0.99 no press

### Callers atualizados
- \`app/(tabs)/index.tsx\` — passa \`onPress\` que faz \`router.push("/lead/[id]")\`
- \`app/(tabs)/leads.tsx\` — \`<Link asChild>\` substituído por \`onPress\` direto; import \`Link\` removido (era unused)

### O que NÃO mudou
- FlatList, RefreshControl, ItemSeparatorComponent, ListEmptyComponent (tudo preservado em ambos os callers — vão ser refatorados na Phase 5)
- Comportamento de navegação idêntico (mesma rota com mesmo param)
- Sem mudança em outros componentes

## Test plan
- [x] \`npm run typecheck\` PASS
- [x] Reviewer subagent (opus): APPROVED, zero blockers
- [x] Cobertura de palette: todas as 4 priorities + 6 statuses mapeadas
- [x] Pressable + Animated.View só renderizam quando \`onPress\` definido (card sem onPress = view inerte)
- [ ] Visual smoke: ver as 4 priorities lado a lado em light/dark (gate manual de manhã)

🤖 Generated with [Claude Code](https://claude.com/claude-code)