### PR TITLE
feat(home): ScreenHeader, greeting, hero KPI, skeleton, ErrorBanner [Phase 5b]

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -18,7 +18,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { ScreenHeader } from "@/components/ui/ScreenHeader";
 import { useTheme } from "@/context/ThemeContext";
-import { api, ApiError, type Lead } from "@/lib/api";
+import { ACTIVE_LEAD_STATUSES, api, ApiError, type Lead } from "@/lib/api";
 import { fetchMyProfile } from "@/lib/profile";
 import { getAccessToken } from "@/lib/session";
 import { supabase } from "@/lib/supabase";
@@ -30,6 +30,12 @@ type HeroStats = {
 };
 
 const TOP_VISIBLE = 5;
+// Hero stats sao calculados client-side a partir do array retornado por listLeads.
+// Sprint 1 nao tem endpoint dedicado de agregacao (/leads/stats), entao puxamos um
+// teto bem acima da expectativa real por vendedor (~50 leads ativos). Quando o backend
+// expor agregacao, trocar isso por uma chamada dedicada e parar de truncar.
+const HERO_FETCH_LIMIT = 200;
+const GREETING_REFRESH_MS = 60_000;
 
 function greetingKey(hour: number): "home.greeting_morning" | "home.greeting_afternoon" | "home.greeting_evening" {
   if (hour < 12) return "home.greeting_morning";
@@ -38,7 +44,7 @@ function greetingKey(hour: number): "home.greeting_morning" | "home.greeting_aft
 }
 
 function computeHeroStats(leads: Lead[]): HeroStats {
-  const activeLeads = leads.filter((l) => l.status !== "lost" && l.status !== "expired").length;
+  const activeLeads = leads.filter((l) => ACTIVE_LEAD_STATUSES.has(l.status)).length;
   const pipelineBRL = leads.reduce((sum, l) => sum + (l.expected_value_brl ?? 0), 0);
   return { activeLeads, pipelineBRL };
 }
@@ -66,12 +72,15 @@ export default function HomeScreen() {
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState<string>("");
+  // Reavalia o greeting periodicamente: sem isso o usuario que abre o app as 11h55
+  // ve "Bom dia" ate fechar e reabrir, mesmo passando do meio-dia.
+  const [now, setNow] = useState(() => new Date());
 
   const load = useCallback(async () => {
     setError(null);
     try {
       const token = (await getAccessToken()) ?? undefined;
-      const data = await api.listLeads({ limit: 50 }, token);
+      const data = await api.listLeads({ limit: HERO_FETCH_LIMIT }, token);
       setLeads(data);
     } catch (e) {
       setError(e instanceof ApiError ? e.message : t("home.error"));
@@ -98,6 +107,11 @@ export default function HomeScreen() {
     })();
   }, []);
 
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), GREETING_REFRESH_MS);
+    return () => clearInterval(id);
+  }, []);
+
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     await load();
@@ -106,14 +120,14 @@ export default function HomeScreen() {
 
   const hero = useMemo(() => computeHeroStats(leads), [leads]);
   const topLeads = useMemo(() => leads.slice(0, TOP_VISIBLE), [leads]);
-  const greeting = t(greetingKey(new Date().getHours()), { name: name || "" });
+  const greeting = t(greetingKey(now.getHours()), { name: name || "" });
 
   return (
     <FlatList
-      style={[styles.container, { paddingTop: insets.top }]}
+      style={styles.container}
       data={initialLoading ? [] : topLeads}
       keyExtractor={(l) => l.id}
-      contentContainerStyle={styles.list}
+      contentContainerStyle={[styles.list, { paddingTop: insets.top }]}
       refreshControl={
         <RefreshControl
           refreshing={refreshing}
@@ -162,7 +176,6 @@ export default function HomeScreen() {
           <Pressable
             onPress={() => router.push("/leads")}
             accessibilityRole="button"
-            accessibilityLabel={t("home.see_all_with_count", { count: leads.length })}
             style={({ pressed }) => [styles.seeAll, pressed && { opacity: 0.7 }]}
           >
             <Text style={styles.seeAllLabel}>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -161,6 +161,8 @@ export default function HomeScreen() {
         !initialLoading && leads.length > TOP_VISIBLE ? (
           <Pressable
             onPress={() => router.push("/leads")}
+            accessibilityRole="button"
+            accessibilityLabel={t("home.see_all_with_count", { count: leads.length })}
             style={({ pressed }) => [styles.seeAll, pressed && { opacity: 0.7 }]}
           >
             <Text style={styles.seeAllLabel}>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,67 +1,172 @@
-import { useEffect, useMemo, useState } from "react";
-import { FlatList, RefreshControl, StyleSheet, Text, View } from "react-native";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
+import { LeadCardSkeleton } from "@/components/domain/LeadCardSkeleton";
+import { Card } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { ScreenHeader } from "@/components/ui/ScreenHeader";
 import { useTheme } from "@/context/ThemeContext";
 import { api, ApiError, type Lead } from "@/lib/api";
+import { fetchMyProfile } from "@/lib/profile";
 import { getAccessToken } from "@/lib/session";
-import { spacing, typography, type ThemeColors } from "@/lib/theme";
+import { supabase } from "@/lib/supabase";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+
+type HeroStats = {
+  activeLeads: number;
+  pipelineBRL: number;
+};
+
+const TOP_VISIBLE = 5;
+
+function greetingKey(hour: number): "home.greeting_morning" | "home.greeting_afternoon" | "home.greeting_evening" {
+  if (hour < 12) return "home.greeting_morning";
+  if (hour < 18) return "home.greeting_afternoon";
+  return "home.greeting_evening";
+}
+
+function computeHeroStats(leads: Lead[]): HeroStats {
+  const activeLeads = leads.filter((l) => l.status !== "lost" && l.status !== "expired").length;
+  const pipelineBRL = leads.reduce((sum, l) => sum + (l.expected_value_brl ?? 0), 0);
+  return { activeLeads, pipelineBRL };
+}
+
+function formatCompactBRL(value: number): string {
+  if (value >= 1000) {
+    const k = value / 1000;
+    return `R$ ${k.toFixed(k >= 10 ? 0 : 1)}k`;
+  }
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
 
 export default function HomeScreen() {
   const { t } = useTranslation();
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
+
   const [leads, setLeads] = useState<Lead[]>([]);
   const [refreshing, setRefreshing] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState<string>("");
 
-  async function load() {
-    setRefreshing(true);
+  const load = useCallback(async () => {
     setError(null);
     try {
       const token = (await getAccessToken()) ?? undefined;
-      const data = await api.listLeads({ limit: 20 }, token);
+      const data = await api.listLeads({ limit: 50 }, token);
       setLeads(data);
     } catch (e) {
       setError(e instanceof ApiError ? e.message : t("home.error"));
-    } finally {
-      setRefreshing(false);
     }
-  }
+  }, [t]);
 
   useEffect(() => {
-    void load();
+    void (async () => {
+      await load();
+      setInitialLoading(false);
+    })();
+  }, [load]);
+
+  useEffect(() => {
+    void (async () => {
+      const profile = await fetchMyProfile().catch(() => null);
+      if (profile?.full_name) {
+        setName(profile.full_name.split(" ")[0]);
+        return;
+      }
+      const auth = await supabase.auth.getUser();
+      const email = auth.data.user?.email;
+      if (email) setName(email.split("@")[0]);
+    })();
   }, []);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  }, [load]);
+
+  const hero = useMemo(() => computeHeroStats(leads), [leads]);
+  const topLeads = useMemo(() => leads.slice(0, TOP_VISIBLE), [leads]);
+  const greeting = t(greetingKey(new Date().getHours()), { name: name || "" });
 
   return (
     <FlatList
-      style={styles.container}
-      data={leads}
+      style={[styles.container, { paddingTop: insets.top }]}
+      data={initialLoading ? [] : topLeads}
       keyExtractor={(l) => l.id}
       contentContainerStyle={styles.list}
       refreshControl={
         <RefreshControl
           refreshing={refreshing}
-          onRefresh={load}
-          tintColor={colors.text}
+          onRefresh={onRefresh}
+          tintColor={colors.primary}
         />
       }
       ListHeaderComponent={
-        <View style={styles.header}>
-          <Text style={styles.title}>{t("home.todays_leads")}</Text>
-          {error ? <Text style={styles.error}>{error}</Text> : null}
+        <View>
+          <ScreenHeader title={t("home.today")} subtitle={greeting.trim()} />
+
+          <Card style={styles.hero}>
+            <View style={styles.heroCol}>
+              <Text style={styles.heroLabel}>{t("home.hero.active_leads")}</Text>
+              <Text style={styles.heroValue}>{hero.activeLeads}</Text>
+            </View>
+            <View style={styles.heroDivider} />
+            <View style={styles.heroCol}>
+              <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
+              <Text style={styles.heroValue}>{formatCompactBRL(hero.pipelineBRL)}</Text>
+            </View>
+          </Card>
+
+          {error ? <ErrorBanner message={error} onRetry={() => void load()} /> : null}
+
+          {initialLoading ? (
+            <View style={styles.skeletonStack}>
+              <LeadCardSkeleton />
+              <LeadCardSkeleton />
+              <LeadCardSkeleton />
+            </View>
+          ) : null}
         </View>
       }
       ListEmptyComponent={
-        !refreshing ? (
+        !initialLoading && !error ? (
           <EmptyState
             icon="briefcase-outline"
             title={t("home.empty_title")}
             description={t("home.empty_description")}
           />
+        ) : null
+      }
+      ListFooterComponent={
+        !initialLoading && leads.length > TOP_VISIBLE ? (
+          <Pressable
+            onPress={() => router.push("/leads")}
+            style={({ pressed }) => [styles.seeAll, pressed && { opacity: 0.7 }]}
+          >
+            <Text style={styles.seeAllLabel}>
+              {t("home.see_all_with_count", { count: leads.length })}
+            </Text>
+          </Pressable>
         ) : null
       }
       renderItem={({ item }) => (
@@ -78,9 +183,50 @@ export default function HomeScreen() {
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
     container: { backgroundColor: c.bg },
-    list: { padding: spacing.lg, paddingBottom: spacing["3xl"] },
-    header: { marginBottom: spacing.lg, gap: spacing.sm },
-    title: { ...typography.h1, color: c.text },
-    error: { ...typography.body, color: c.error },
+    list: { paddingBottom: spacing["4xl"] },
+    hero: {
+      flexDirection: "row",
+      alignItems: "stretch",
+      marginHorizontal: spacing.xl,
+      marginBottom: spacing.lg,
+      padding: spacing.lg,
+    },
+    heroCol: { flex: 1, gap: spacing.xs },
+    heroDivider: {
+      width: 1,
+      backgroundColor: c.separator,
+      marginHorizontal: spacing.md,
+    },
+    heroLabel: {
+      ...typography.label,
+      color: c.textMuted,
+      textTransform: "uppercase",
+    },
+    heroValue: {
+      ...typography.mono,
+      fontSize: 28,
+      color: c.text,
+      fontWeight: "800",
+      letterSpacing: -0.3,
+    },
+    skeletonStack: {
+      gap: spacing.md,
+      paddingHorizontal: spacing.xl,
+    },
+    seeAll: {
+      marginTop: spacing.lg,
+      marginHorizontal: spacing.xl,
+      paddingVertical: spacing.md,
+      borderRadius: radius.md,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.surface,
+      alignItems: "center",
+    },
+    seeAllLabel: {
+      ...typography.caption,
+      fontWeight: "700",
+      color: c.primary,
+    },
   });
 }

--- a/components/ui/ErrorBanner.tsx
+++ b/components/ui/ErrorBanner.tsx
@@ -4,8 +4,8 @@
 // Banner inline de erro: icon + mensagem + retry opcional.
 
 import { Ionicons } from "@expo/vector-icons";
-import { useMemo } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useMemo, useState } from "react";
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 import { useTheme } from "@/context/ThemeContext";
@@ -14,7 +14,8 @@ import { haptic } from "@/lib/haptics";
 
 export interface ErrorBannerProps {
   message: string;
-  onRetry?: () => void;
+  /** Sync ou async. Quando async, o banner mostra spinner ate a promise resolver. */
+  onRetry?: () => void | Promise<void>;
   /** Override the default retry label. Pass an i18n key if you want a non-default label. */
   retryLabel?: string;
 }
@@ -23,6 +24,18 @@ export function ErrorBanner({ message, onRetry, retryLabel }: ErrorBannerProps) 
   const { t } = useTranslation();
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
+  const [retrying, setRetrying] = useState(false);
+
+  const handleRetry = async () => {
+    if (!onRetry || retrying) return;
+    haptic.light();
+    try {
+      setRetrying(true);
+      await onRetry();
+    } finally {
+      setRetrying(false);
+    }
+  };
 
   return (
     <View style={styles.container}>
@@ -32,16 +45,23 @@ export function ErrorBanner({ message, onRetry, retryLabel }: ErrorBannerProps) 
       </Text>
       {onRetry ? (
         <Pressable
-          onPress={() => {
-            haptic.light();
-            onRetry();
-          }}
+          onPress={handleRetry}
+          disabled={retrying}
           hitSlop={8}
           accessibilityRole="button"
           accessibilityLabel={retryLabel ?? t("common.retry")}
-          style={({ pressed }) => [styles.retry, pressed && { opacity: 0.7 }]}
+          accessibilityState={{ busy: retrying, disabled: retrying }}
+          style={({ pressed }) => [
+            styles.retry,
+            pressed && !retrying && { opacity: 0.7 },
+            retrying && { opacity: 0.85 },
+          ]}
         >
-          <Text style={styles.retryLabel}>{retryLabel ?? t("common.retry")}</Text>
+          {retrying ? (
+            <ActivityIndicator size="small" color={colors.error} />
+          ) : (
+            <Text style={styles.retryLabel}>{retryLabel ?? t("common.retry")}</Text>
+          )}
         </Pressable>
       ) : null}
     </View>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -35,7 +35,6 @@
       "active_leads": "Active leads",
       "pipeline": "Pipeline"
     },
-    "see_all": "See all leads",
     "see_all_with_count": "See all {{count}} leads"
   },
   "loading": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -22,12 +22,21 @@
     "profile": "Profile"
   },
   "home": {
-    "greeting": "Hello",
+    "greeting_morning": "Good morning, {{name}}",
+    "greeting_afternoon": "Good afternoon, {{name}}",
+    "greeting_evening": "Good evening, {{name}}",
+    "today": "Today",
     "todays_leads": "Today's leads",
     "empty": "No leads at the moment",
     "empty_title": "No leads yet",
     "empty_description": "When new leads are assigned to you, they will show up here.",
-    "error": "Failed to load data"
+    "error": "Failed to load data",
+    "hero": {
+      "active_leads": "Active leads",
+      "pipeline": "Pipeline"
+    },
+    "see_all": "See all leads",
+    "see_all_with_count": "See all {{count}} leads"
   },
   "loading": {
     "profile": "Loading profile"

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -26,12 +26,21 @@
     "profile": "Perfil"
   },
   "home": {
-    "greeting": "Ola",
+    "greeting_morning": "Bom dia, {{name}}",
+    "greeting_afternoon": "Boa tarde, {{name}}",
+    "greeting_evening": "Boa noite, {{name}}",
+    "today": "Hoje",
     "todays_leads": "Leads de hoje",
     "empty": "Nenhum lead no momento",
     "empty_title": "Sem leads por enquanto",
     "empty_description": "Quando novos leads forem atribuidos a voce, eles aparecem aqui.",
-    "error": "Falha ao carregar dados"
+    "error": "Falha ao carregar dados",
+    "hero": {
+      "active_leads": "Leads ativos",
+      "pipeline": "Pipeline"
+    },
+    "see_all": "Ver todos os leads",
+    "see_all_with_count": "Ver todos os {{count}} leads"
   },
   "loading": {
     "profile": "Carregando perfil"

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -39,7 +39,6 @@
       "active_leads": "Leads ativos",
       "pipeline": "Pipeline"
     },
-    "see_all": "Ver todos os leads",
     "see_all_with_count": "Ver todos os {{count}} leads"
   },
   "loading": {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -67,6 +67,17 @@ export interface Lead {
   created_at: string;
 }
 
+export type LeadStatus = Lead["status"];
+
+// Active = ainda no funil. Excluir explicitamente os terminais protege contra
+// novos status surgirem no backend e silenciosamente quebrarem a contagem.
+export const ACTIVE_LEAD_STATUSES: ReadonlySet<LeadStatus> = new Set([
+  "new",
+  "assigned",
+  "contacted",
+  "converted",
+]);
+
 export interface ChurnScore {
   id: string;
   customer_id: string;


### PR DESCRIPTION
## Summary
Phase 5b — Home recebe o tratamento completo do Design DNA. Greeting personalizado, KPIs em mono, top 5 leads, skeleton durante load.

### Mudanças em \`app/(tabs)/index.tsx\`
- **ScreenHeader** com title "Hoje" + greeting subtitle ("Bom dia/tarde/noite, {{nome}}" baseado em hora local)
- Nome puxa de \`profile.full_name\` (primeiro nome só) com fallback pro prefixo do email
- **Hero KPI card** com 2 colunas: "Leads ativos" (count em mono 28px) + "Pipeline" (R\$ Xk compacto em mono)
- **LeadCardSkeleton x3** durante \`initialLoading\` (não aparece em refreshes subsequentes)
- **ErrorBanner** com retry no lugar do \`<Text style={error}>\`
- Top 5 leads visíveis; footer "Ver todos N leads" se houver mais
- Pull-to-refresh com tint primary

### i18n
- Bloco \`home\` reescrito: greetings (morning/afternoon/evening), \`today\`, \`hero.active_leads\`/\`hero.pipeline\`, \`see_all_with_count\`

## Test plan
- [x] \`npm run typecheck\` PASS
- [ ] Manual visual: greeting muda com hora, hero em mono, skeleton em loading, error retry funciona (QA de manhã)

🤖 Generated with [Claude Code](https://claude.com/claude-code)