### PR TITLE
feat(leads): ScreenHeader, search, filter chips, skeleton, ErrorBanner [Phase 5c]

### DIFF
--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -20,13 +20,29 @@ import { Input } from "@/components/ui/Input";
 import { ScreenHeader } from "@/components/ui/ScreenHeader";
 import { useTheme } from "@/context/ThemeContext";
 import { haptic } from "@/lib/haptics";
-import { api, ApiError, type Lead } from "@/lib/api";
+import { ACTIVE_LEAD_STATUSES, api, ApiError, type Lead } from "@/lib/api";
 import { getAccessToken } from "@/lib/session";
 import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
-type FilterKey = "all" | "critical" | "today" | "no_contact";
+type FilterKey = "all" | "critical" | "today" | "forgotten";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseTimestamp(s: string | undefined): number | null {
+  if (!s) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+function startOfTodayMs(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function normalize(s: string): string {
+  return s.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+}
 
 function applyFilters(leads: Lead[], filter: FilterKey, query: string): Lead[] {
   let out = leads;
@@ -36,15 +52,24 @@ function applyFilters(leads: Lead[], filter: FilterKey, query: string): Lead[] {
       out = out.filter((l) => l.priority === "critical");
       break;
     case "today": {
-      const cutoff = Date.now() - DAY_MS;
-      out = out.filter((l) => Date.parse(l.created_at) >= cutoff);
+      // Hoje = a partir do inicio do dia local, nao "ultimas 24h".
+      const cutoff = startOfTodayMs();
+      out = out.filter((l) => {
+        const t = parseTimestamp(l.created_at);
+        return t !== null && t >= cutoff;
+      });
       break;
     }
-    case "no_contact": {
+    case "forgotten": {
+      // Proxy para "sem follow-up ha >=30d": status ainda nao avancou
+      // (new/assigned) e created_at >=30d atras. Quando o backend expor
+      // last_contact_at, trocar pra esse campo.
       const cutoff = Date.now() - 30 * DAY_MS;
-      out = out.filter(
-        (l) => l.status !== "contacted" && l.status !== "converted" && Date.parse(l.created_at) <= cutoff,
-      );
+      out = out.filter((l) => {
+        if (l.status === "contacted" || l.status === "converted") return false;
+        const t = parseTimestamp(l.created_at);
+        return t !== null && t <= cutoff;
+      });
       break;
     }
     case "all":
@@ -52,12 +77,12 @@ function applyFilters(leads: Lead[], filter: FilterKey, query: string): Lead[] {
       break;
   }
 
-  const q = query.trim().toLowerCase();
+  const q = normalize(query.trim());
   if (q.length > 0) {
     out = out.filter(
       (l) =>
-        (l.vin ?? "").toLowerCase().includes(q) ||
-        (l.reason ?? "").toLowerCase().includes(q),
+        normalize(l.vin ?? "").includes(q) ||
+        normalize(l.reason ?? "").includes(q),
     );
   }
 
@@ -102,9 +127,10 @@ export default function LeadsScreen() {
 
   const filtered = useMemo(() => applyFilters(leads, filter, query), [leads, filter, query]);
   const activeCount = useMemo(
-    () => leads.filter((l) => l.status !== "lost" && l.status !== "expired").length,
+    () => leads.filter((l) => ACTIVE_LEAD_STATUSES.has(l.status)).length,
     [leads],
   );
+  const isFiltering = filter !== "all" || query.trim().length > 0;
 
   function onFilterPress(k: FilterKey) {
     haptic.selection();
@@ -116,8 +142,8 @@ export default function LeadsScreen() {
       <ScreenHeader
         title={t("leads.title")}
         subtitle={
-          activeCount === 1
-            ? t("leads.subtitle_count_one", { count: activeCount })
+          isFiltering
+            ? t("leads.subtitle_showing", { showing: filtered.length, total: activeCount })
             : t("leads.subtitle_count", { count: activeCount })
         }
       />
@@ -134,9 +160,10 @@ export default function LeadsScreen() {
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
           contentContainerStyle={styles.chips}
         >
-          {(["all", "critical", "today", "no_contact"] as FilterKey[]).map((k) => {
+          {(["all", "critical", "today", "forgotten"] as FilterKey[]).map((k) => {
             const active = filter === k;
             return (
               <Pressable

--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -1,64 +1,254 @@
-import { useEffect, useMemo, useState } from "react";
-import { FlatList, StyleSheet, Text, View } from "react-native";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
+import { LeadCardSkeleton } from "@/components/domain/LeadCardSkeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { Input } from "@/components/ui/Input";
+import { ScreenHeader } from "@/components/ui/ScreenHeader";
 import { useTheme } from "@/context/ThemeContext";
+import { haptic } from "@/lib/haptics";
 import { api, ApiError, type Lead } from "@/lib/api";
 import { getAccessToken } from "@/lib/session";
-import { spacing, typography, type ThemeColors } from "@/lib/theme";
+import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+
+type FilterKey = "all" | "critical" | "today" | "no_contact";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function applyFilters(leads: Lead[], filter: FilterKey, query: string): Lead[] {
+  let out = leads;
+
+  switch (filter) {
+    case "critical":
+      out = out.filter((l) => l.priority === "critical");
+      break;
+    case "today": {
+      const cutoff = Date.now() - DAY_MS;
+      out = out.filter((l) => Date.parse(l.created_at) >= cutoff);
+      break;
+    }
+    case "no_contact": {
+      const cutoff = Date.now() - 30 * DAY_MS;
+      out = out.filter(
+        (l) => l.status !== "contacted" && l.status !== "converted" && Date.parse(l.created_at) <= cutoff,
+      );
+      break;
+    }
+    case "all":
+    default:
+      break;
+  }
+
+  const q = query.trim().toLowerCase();
+  if (q.length > 0) {
+    out = out.filter(
+      (l) =>
+        (l.vin ?? "").toLowerCase().includes(q) ||
+        (l.reason ?? "").toLowerCase().includes(q),
+    );
+  }
+
+  return out;
+}
 
 export default function LeadsScreen() {
   const { t } = useTranslation();
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
+
   const [leads, setLeads] = useState<Lead[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterKey>("all");
+  const [query, setQuery] = useState("");
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const token = (await getAccessToken()) ?? undefined;
+      setLeads(await api.listLeads({ limit: 100 }, token));
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : t("home.error"));
+    }
+  }, [t]);
 
   useEffect(() => {
-    (async () => {
-      try {
-        const token = (await getAccessToken()) ?? undefined;
-        setLeads(await api.listLeads({ limit: 100 }, token));
-      } catch (e) {
-        setError(e instanceof ApiError ? e.message : t("home.error"));
-      }
+    void (async () => {
+      await load();
+      setInitialLoading(false);
     })();
-  }, []);
+  }, [load]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  }, [load]);
+
+  const filtered = useMemo(() => applyFilters(leads, filter, query), [leads, filter, query]);
+  const activeCount = useMemo(
+    () => leads.filter((l) => l.status !== "lost" && l.status !== "expired").length,
+    [leads],
+  );
+
+  function onFilterPress(k: FilterKey) {
+    haptic.selection();
+    setFilter(k);
+  }
 
   return (
-    <FlatList
-      style={styles.container}
-      data={leads}
-      keyExtractor={(l) => l.id}
-      contentContainerStyle={styles.list}
-      ListHeaderComponent={error ? <Text style={styles.error}>{error}</Text> : null}
-      ListEmptyComponent={
-        !error ? (
-          <EmptyState
-            icon="briefcase-outline"
-            title={t("home.empty_title")}
-            description={t("home.empty_description")}
-          />
-        ) : null
-      }
-      renderItem={({ item }) => (
-        <LeadCard
-          lead={item}
-          onPress={() => router.push({ pathname: "/lead/[id]", params: { id: item.id } })}
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      <ScreenHeader
+        title={t("leads.title")}
+        subtitle={
+          activeCount === 1
+            ? t("leads.subtitle_count_one", { count: activeCount })
+            : t("leads.subtitle_count", { count: activeCount })
+        }
+      />
+
+      <View style={styles.controls}>
+        <Input
+          value={query}
+          onChangeText={setQuery}
+          placeholder={t("leads.search_placeholder")}
+          icon="search-outline"
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.chips}
+        >
+          {(["all", "critical", "today", "no_contact"] as FilterKey[]).map((k) => {
+            const active = filter === k;
+            return (
+              <Pressable
+                key={k}
+                onPress={() => onFilterPress(k)}
+                style={({ pressed }) => [
+                  styles.chip,
+                  active && styles.chipActive,
+                  pressed && { opacity: 0.8 },
+                ]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+              >
+                <Text style={[styles.chipLabel, active && styles.chipLabelActive]}>
+                  {t(`leads.filter.${k}`)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+
+      {error ? <ErrorBanner message={error} onRetry={() => void load()} /> : null}
+
+      {initialLoading ? (
+        <View style={styles.skeletonStack}>
+          <LeadCardSkeleton />
+          <LeadCardSkeleton />
+          <LeadCardSkeleton />
+          <LeadCardSkeleton />
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={(l) => l.id}
+          contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.primary}
+            />
+          }
+          ListEmptyComponent={
+            !error ? (
+              query.trim().length > 0 ? (
+                <EmptyState
+                  icon="search-outline"
+                  title={t("leads.empty_search_title")}
+                  description={t("leads.empty_search_description", { query: query.trim() })}
+                />
+              ) : (
+                <EmptyState
+                  icon="briefcase-outline"
+                  title={t("home.empty_title")}
+                  description={t("home.empty_description")}
+                />
+              )
+            ) : null
+          }
+          renderItem={({ item }) => (
+            <LeadCard
+              lead={item}
+              onPress={() => router.push({ pathname: "/lead/[id]", params: { id: item.id } })}
+            />
+          )}
+          ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
         />
       )}
-      ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
-    />
+    </View>
   );
 }
 
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { backgroundColor: c.bg },
-    list: { padding: spacing.lg, paddingBottom: spacing["3xl"] },
-    error: { ...typography.body, color: c.error, marginBottom: spacing.md },
+    container: { flex: 1, backgroundColor: c.bg },
+    controls: {
+      paddingHorizontal: spacing.xl,
+      gap: spacing.md,
+      marginBottom: spacing.md,
+    },
+    chips: {
+      gap: spacing.sm,
+      paddingVertical: spacing.xs,
+    },
+    chip: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.xs + 2,
+      borderRadius: radius.pill,
+      backgroundColor: c.surface,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    chipActive: {
+      backgroundColor: c.primary,
+      borderColor: c.primary,
+    },
+    chipLabel: {
+      ...typography.caption,
+      fontWeight: "600",
+      color: c.text,
+    },
+    chipLabelActive: {
+      color: c.primaryText,
+    },
+    skeletonStack: {
+      gap: spacing.md,
+      paddingHorizontal: spacing.xl,
+    },
+    list: {
+      padding: spacing.xl,
+      paddingBottom: spacing["4xl"],
+    },
   });
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -58,6 +58,20 @@
     "call": "Call",
     "message": "Send WhatsApp"
   },
+  "leads": {
+    "title": "Leads",
+    "subtitle_count": "{{count}} active",
+    "subtitle_count_one": "{{count}} active",
+    "search_placeholder": "Search by VIN or reason",
+    "filter": {
+      "all": "All",
+      "critical": "Critical",
+      "today": "Today",
+      "no_contact": "No contact 30d+"
+    },
+    "empty_search_title": "Nothing found",
+    "empty_search_description": "No leads for '{{query}}'. Try a partial VIN or another filter."
+  },
   "segment": {
     "fiel": "Loyal",
     "abandono": "Churner",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -60,14 +60,15 @@
   },
   "leads": {
     "title": "Leads",
-    "subtitle_count": "{{count}} active",
     "subtitle_count_one": "{{count}} active",
+    "subtitle_count_other": "{{count}} active",
+    "subtitle_showing": "Showing {{showing}} of {{total}}",
     "search_placeholder": "Search by VIN or reason",
     "filter": {
       "all": "All",
       "critical": "Critical",
       "today": "Today",
-      "no_contact": "No contact 30d+"
+      "forgotten": "Forgotten 30d+"
     },
     "empty_search_title": "Nothing found",
     "empty_search_description": "No leads for '{{query}}'. Try a partial VIN or another filter."

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -62,6 +62,20 @@
     "call": "Ligar",
     "message": "Enviar WhatsApp"
   },
+  "leads": {
+    "title": "Leads",
+    "subtitle_count": "{{count}} ativos",
+    "subtitle_count_one": "{{count}} ativo",
+    "search_placeholder": "Buscar por VIN ou motivo",
+    "filter": {
+      "all": "Todos",
+      "critical": "Críticos",
+      "today": "Hoje",
+      "no_contact": "Sem contato 30d+"
+    },
+    "empty_search_title": "Nada encontrado",
+    "empty_search_description": "Sem leads para '{{query}}'. Tente VIN parcial ou outro filtro."
+  },
   "segment": {
     "fiel": "Fiel",
     "abandono": "Abandono",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -64,14 +64,15 @@
   },
   "leads": {
     "title": "Leads",
-    "subtitle_count": "{{count}} ativos",
     "subtitle_count_one": "{{count}} ativo",
+    "subtitle_count_other": "{{count}} ativos",
+    "subtitle_showing": "Mostrando {{showing}} de {{total}}",
     "search_placeholder": "Buscar por VIN ou motivo",
     "filter": {
       "all": "Todos",
       "critical": "Críticos",
       "today": "Hoje",
-      "no_contact": "Sem contato 30d+"
+      "forgotten": "Esquecidos 30d+"
     },
     "empty_search_title": "Nada encontrado",
     "empty_search_description": "Sem leads para '{{query}}'. Tente VIN parcial ou outro filtro."


### PR DESCRIPTION
## Summary
Phase 5c — Leads ganha o tratamento completo. Header, busca, 4 filter chips, skeleton, retry no erro.

### Mudanças em \`app/(tabs)/leads.tsx\`
- **ScreenHeader** "Leads" / "{N} ativos" (singular vs plural i18n)
- **Input de busca** com search-outline; filtra client-side por VIN e reason (case-insensitive)
- **4 chips de filtro**: Todos / Críticos / Hoje (último 24h) / Sem contato 30d+ — chip ativo em primary, demais surface; haptic selection na troca
- **LeadCardSkeleton x4** durante initial load
- **RefreshControl** com tint primary
- **ErrorBanner** com retry no lugar do \`<Text style={error}>\`
- **Empty states diferenciados**: busca vazia mostra "Nada encontrado para 'X'", sem dados mostra default

### i18n
- Novo bloco \`leads\` (não existia): \`title\`, \`subtitle_count\`/\`subtitle_count_one\`, \`search_placeholder\`, \`filter.all\`/\`critical\`/\`today\`/\`no_contact\`, \`empty_search_title\`/\`empty_search_description\`

## Test plan
- [x] \`npm run typecheck\` PASS
- [ ] Manual: busca, filtros, empty states, refresh (QA de manhã)

## PRs relacionadas
- [PR #18](https://github.com/fwd-ford/forward-mobile/pull/18) Phase 5a login (merged)
- [PR #19](https://github.com/fwd-ford/forward-mobile/pull/19) Phase 5b home (open)
- Phase 5d/5e/6 vindo na sequência

🤖 Generated with [Claude Code](https://claude.com/claude-code)