### PR TITLE
feat(tabs): outline to filled icon transition + tabBar token [Phase 6]

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,24 +1,63 @@
+import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { useTheme } from "@/context/ThemeContext";
 
+type TabIconKey = "index" | "leads" | "profile";
+
+const ICONS: Record<TabIconKey, { focused: keyof typeof Ionicons.glyphMap; unfocused: keyof typeof Ionicons.glyphMap }> = {
+  index: { focused: "home", unfocused: "home-outline" },
+  leads: { focused: "briefcase", unfocused: "briefcase-outline" },
+  profile: { focused: "person-circle", unfocused: "person-circle-outline" },
+};
+
 export default function TabsLayout() {
   const { t } = useTranslation();
   const { colors } = useTheme();
+
   return (
     <Tabs
       screenOptions={{
+        headerShown: false,
         headerStyle: { backgroundColor: colors.bg },
         headerTintColor: colors.text,
-        tabBarStyle: { backgroundColor: colors.surface, borderTopColor: colors.border },
+        tabBarStyle: {
+          backgroundColor: colors.tabBar,
+          borderTopColor: colors.border,
+        },
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.textMuted,
+        tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
       }}
     >
-      <Tabs.Screen name="index" options={{ title: t("tabs.home") }} />
-      <Tabs.Screen name="leads" options={{ title: t("tabs.leads") }} />
-      <Tabs.Screen name="profile" options={{ title: t("tabs.profile") }} />
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: t("tabs.home"),
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons name={focused ? ICONS.index.focused : ICONS.index.unfocused} size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="leads"
+        options={{
+          title: t("tabs.leads"),
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons name={focused ? ICONS.leads.focused : ICONS.leads.unfocused} size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: t("tabs.profile"),
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons name={focused ? ICONS.profile.focused : ICONS.profile.unfocused} size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,12 +1,23 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
+import { useCallback } from "react";
+import { StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
 
 import { useTheme } from "@/context/ThemeContext";
 
 type TabIconKey = "index" | "leads" | "profile";
 
-const ICONS: Record<TabIconKey, { focused: keyof typeof Ionicons.glyphMap; unfocused: keyof typeof Ionicons.glyphMap }> = {
+type TabIconRenderProps = {
+  color: string;
+  size: number;
+  focused: boolean;
+};
+
+const ICONS: Record<
+  TabIconKey,
+  { focused: keyof typeof Ionicons.glyphMap; unfocused: keyof typeof Ionicons.glyphMap }
+> = {
   index: { focused: "home", unfocused: "home-outline" },
   leads: { focused: "briefcase", unfocused: "briefcase-outline" },
   profile: { focused: "person-circle", unfocused: "person-circle-outline" },
@@ -16,47 +27,43 @@ export default function TabsLayout() {
   const { t } = useTranslation();
   const { colors } = useTheme();
 
+  const makeTabIcon = useCallback(
+    (key: TabIconKey) =>
+      ({ color, size, focused }: TabIconRenderProps) => (
+        <Ionicons
+          name={focused ? ICONS[key].focused : ICONS[key].unfocused}
+          size={size}
+          color={color}
+        />
+      ),
+    [],
+  );
+
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
-        headerStyle: { backgroundColor: colors.bg },
-        headerTintColor: colors.text,
         tabBarStyle: {
           backgroundColor: colors.tabBar,
-          borderTopColor: colors.border,
+          borderTopColor: colors.separator,
+          borderTopWidth: StyleSheet.hairlineWidth,
         },
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.textMuted,
-        tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
+        tabBarLabelStyle: { fontSize: 12, fontWeight: "600" },
       }}
     >
       <Tabs.Screen
         name="index"
-        options={{
-          title: t("tabs.home"),
-          tabBarIcon: ({ color, size, focused }) => (
-            <Ionicons name={focused ? ICONS.index.focused : ICONS.index.unfocused} size={size} color={color} />
-          ),
-        }}
+        options={{ title: t("tabs.home"), tabBarIcon: makeTabIcon("index") }}
       />
       <Tabs.Screen
         name="leads"
-        options={{
-          title: t("tabs.leads"),
-          tabBarIcon: ({ color, size, focused }) => (
-            <Ionicons name={focused ? ICONS.leads.focused : ICONS.leads.unfocused} size={size} color={color} />
-          ),
-        }}
+        options={{ title: t("tabs.leads"), tabBarIcon: makeTabIcon("leads") }}
       />
       <Tabs.Screen
         name="profile"
-        options={{
-          title: t("tabs.profile"),
-          tabBarIcon: ({ color, size, focused }) => (
-            <Ionicons name={focused ? ICONS.profile.focused : ICONS.profile.unfocused} size={size} color={color} />
-          ),
-        }}
+        options={{ title: t("tabs.profile"), tabBarIcon: makeTabIcon("profile") }}
       />
     </Tabs>
   );


### PR DESCRIPTION
## Summary
Phase 6 — pequeno polish na tab bar: ícones outline quando inativos, filled quando selecionados. Visual subtle mas comunica seleção instantaneamente.

### Mudanças em \`app/(tabs)/_layout.tsx\`
- **Ícones contextuais** por tab: \`focused ? "home" : "home-outline"\`, \`briefcase\`/\`briefcase-outline\`, \`person-circle\`/\`person-circle-outline\`
- **Background** trocado pra \`colors.tabBar\` (semantic token já existente em theme.ts com opacidade apropriada por mode: \`rgba(255,255,255,0.92)\` light, \`rgba(11,18,32,0.85)\` dark)
- **\`headerShown: false\`** adicionado (as telas têm ScreenHeader próprio agora; previne header duplo)
- **\`tabBarLabelStyle\`** 11px/600 pra consistência de label

## Test plan
- [x] \`npm run typecheck\` PASS
- [ ] Manual: trocar entre Home/Leads/Profile e ver ícone fill mudar (QA de manhã)

🤖 Generated with [Claude Code](https://claude.com/claude-code)