### PR TITLE
docs: final EXECUTION_LOG + WAKE_UP_SUMMARY [Phase 7]

### DIFF
--- a/docs/superpowers/EXECUTION_LOG.md
+++ b/docs/superpowers/EXECUTION_LOG.md
@@ -1,6 +1,6 @@
-# Execution Log — Mobile Polish Autonomous Run
+# Execution Log: Mobile Polish Autonomous Run
 
-**Started:** 2026-05-23 (sessão autônoma overnight)
+**Started:** 2026-05-23 (sessao autonoma overnight)
 **Spec:** [specs/2026-05-23-mobile-polish-design.md](specs/2026-05-23-mobile-polish-design.md)
 **Plan:** [plans/2026-05-23-mobile-polish-design.md](plans/2026-05-23-mobile-polish-design.md)
 
@@ -8,64 +8,66 @@
 
 - **Modelo:** todos os subagentes Opus (`model: "opus"` em cada dispatch)
 - **PR strategy inicial:** serial per-phase com squash merge
-- **PR strategy ajustada (após instrução do Jota mid-run):** Phases 5a-5e + 6 viraram 1 PR por screen/tab — branches independentes off main, abertas pra review pelos 2 agentes externos do Jota
-- **Halt policy:** strict — 2 task failures consecutivas → STOP (não acionada, zero failures)
-- **Push-to-main:** PROIBIDO. Sempre via PR. ✓
-- **Stash preservado:** `stash@{0}` com docs polish do `chore/add-secrets-scan-ci` — NÃO MEXIDO ✓
+- **PR strategy ajustada (apos instrucao do Jota mid-run):** Phases 5a-5e + 6 viraram 1 PR por screen/tab. Branches independentes off main, abertas pra review pelos 2 agentes externos do Jota
+- **Halt policy:** strict, 2 task failures consecutivas viram STOP (nao acionada, zero failures)
+- **Push-to-main:** PROIBIDO. Sempre via PR. OK
+- **Stash preservado:** `stash@{0}` com docs polish do `chore/add-secrets-scan-ci` (NAO MEXIDO)
 
 ## Status final
 
 | Phase | Branch | PR | Status |
 |---|---|---|---|
-| 0 | feat/polish-design-system | [#13](https://github.com/fwd-ford/forward-mobile/pull/13) | **MERGED** — spec + plan + EXECUTION_LOG |
-| 1 | feat/polish-phase-1-foundation | [#14](https://github.com/fwd-ford/forward-mobile/pull/14) | **MERGED** — theme.ts: mono + letter-spacing + elevation aliases |
-| 2 | feat/polish-phase-2-intro-fix | [#15](https://github.com/fwd-ford/forward-mobile/pull/15) | **MERGED** — IntroVideo web autoplay fix |
-| 3 | feat/polish-phase-3-shared-infra | [#16](https://github.com/fwd-ford/forward-mobile/pull/16) | **MERGED** — relative-time + ScreenHeader + ErrorBanner + LeadCardSkeleton + extract PhotoButton |
-| 4 | feat/polish-phase-4-leadcard | [#17](https://github.com/fwd-ford/forward-mobile/pull/17) | **MERGED** — LeadCard rewrite (stripe + chip + mono VIN + dot + relative time) |
-| 5a | feat/polish-phase-5a-login | [#18](https://github.com/fwd-ford/forward-mobile/pull/18) | **MERGED** — Login: FORD wordmark + forgot-password footer + scale-in |
-| 5b | feat/polish-phase-5b-home | [#19](https://github.com/fwd-ford/forward-mobile/pull/19) | **OPEN** — Home: ScreenHeader + greeting + hero KPI + skeleton + ErrorBanner + top 5 (+ a11y fix on "See all") |
-| 5c | feat/polish-phase-5c-leads | [#20](https://github.com/fwd-ford/forward-mobile/pull/20) | **OPEN** — Leads: ScreenHeader + search + 4 filter chips + skeleton + ErrorBanner + RefreshControl |
-| 5d | feat/polish-phase-5d-profile | [#21](https://github.com/fwd-ford/forward-mobile/pull/21) | **OPEN** — Profile: ScreenHeader + unified user card + SettingRow + ghost sign-out |
-| 5e | feat/polish-phase-5e-lead-detail | [#22](https://github.com/fwd-ford/forward-mobile/pull/22) | **OPEN** — Lead detail: VIN mono + palette badges + sections + fixed footer actions + skeleton + ErrorBanner |
-| 6 | feat/polish-phase-6-tabs | [#23](https://github.com/fwd-ford/forward-mobile/pull/23) | **OPEN** — Tab bar: outline → filled icons + tabBar token + label sizing |
-| 7 | feat/polish-phase-7-log-summary | (this PR) | **OPEN** — Final EXECUTION_LOG + WAKE_UP_SUMMARY |
+| 0 | feat/polish-design-system | [#13](https://github.com/fwd-ford/forward-mobile/pull/13) | **MERGED** spec + plan + EXECUTION_LOG |
+| 1 | feat/polish-phase-1-foundation | [#14](https://github.com/fwd-ford/forward-mobile/pull/14) | **MERGED** theme.ts: mono + letter-spacing + elevation aliases |
+| 2 | feat/polish-phase-2-intro-fix | [#15](https://github.com/fwd-ford/forward-mobile/pull/15) | **MERGED** IntroVideo web autoplay fix |
+| 3 | feat/polish-phase-3-shared-infra | [#16](https://github.com/fwd-ford/forward-mobile/pull/16) | **MERGED** relative-time + ScreenHeader + ErrorBanner + LeadCardSkeleton + extract PhotoButton |
+| 4 | feat/polish-phase-4-leadcard | [#17](https://github.com/fwd-ford/forward-mobile/pull/17) | **MERGED** LeadCard rewrite (stripe + chip + mono VIN + dot + relative time) |
+| 5a | feat/polish-phase-5a-login | [#18](https://github.com/fwd-ford/forward-mobile/pull/18) | **MERGED** Login: FORD wordmark + forgot-password footer + scale-in |
+| 5b | feat/polish-phase-5b-home | [#19](https://github.com/fwd-ford/forward-mobile/pull/19) | **OPEN** Home: ScreenHeader + greeting + hero KPI + skeleton + ErrorBanner + top 5 (+ a11y fix on "See all") |
+| 5c | feat/polish-phase-5c-leads | [#20](https://github.com/fwd-ford/forward-mobile/pull/20) | **OPEN** Leads: ScreenHeader + search + 4 filter chips + skeleton + ErrorBanner + RefreshControl |
+| 5d | feat/polish-phase-5d-profile | [#21](https://github.com/fwd-ford/forward-mobile/pull/21) | **OPEN** Profile: ScreenHeader + unified user card + SettingRow + ghost sign-out |
+| 5e | feat/polish-phase-5e-lead-detail | [#22](https://github.com/fwd-ford/forward-mobile/pull/22) | **OPEN** Lead detail: VIN mono + palette badges + sections + fixed footer actions + skeleton + ErrorBanner |
+| 6 | feat/polish-phase-6-tabs | [#23](https://github.com/fwd-ford/forward-mobile/pull/23) | **OPEN** Tab bar: outline para filled icons + tabBar token + label sizing |
+| 7 | feat/polish-phase-7-log-summary | (this PR) | **OPEN** Final EXECUTION_LOG + WAKE_UP_SUMMARY |
 
 ## Validations executadas
 
 ### Por phase
-- `npm run typecheck` PASS em **cada** task após cada implementer subagent
-- Reviewer subagent (`pr-review-toolkit:code-reviewer`, Opus) em cada phase — todos APPROVED
-- Gitleaks (única CI configurada) PASS em todas as 11 PRs criadas
+- `npm run typecheck` PASS em **cada** task apos cada implementer subagent
+- Reviewer subagent (`pr-review-toolkit:code-reviewer`, Opus) em cada phase. **Aprovacao condicional**, nao bloqueante: vide secao "Limitacoes conhecidas" abaixo sobre o escopo dessa revisao automatica
+- Gitleaks (unica CI configurada) PASS em todas as 11 PRs criadas
 
 ### Pre-merge audit final (combined state das 5 PRs abertas)
-Mergeado localmente em `verify/combined-phase-5-6` (branch local descartada), typecheck PASS no estado combinado. Reviewer auditou e encontrou 1 blocker:
-- **a11y:** Pressable "See all leads" sem `accessibilityRole`/`Label` → fixado em commit adicional no PR #19
+Mergeado localmente em `verify/combined-phase-5-6` (branch local descartada), typecheck PASS no estado combinado. Auditor encontrou 1 issue:
 
-i18n parity verificada: 16 top-level blocks idênticos entre pt-BR e en. Nested keys alinhadas em todos os blocos modificados (home, leads, lead, auth, common, time).
+- **a11y:** Pressable "See all leads" sem `accessibilityRole`/`Label`. Fixado em commit adicional no PR #19
 
-## Limitações conhecidas
+i18n parity verificada: 16 top-level blocks identicos entre pt-BR e en. Nested keys alinhadas em todos os blocos modificados (home, leads, lead, auth, common, time).
 
-- **`npm run lint`** quebrado por config ausente do ESLint no projeto (pre-existing, não introduzido nesta run). Verificação por `typecheck` apenas.
-- **Smoke test visual** não executado — autonomia não pode ver tela renderizada. Manual QA matinal necessário (ver WAKE_UP_SUMMARY.md).
-- **iOS sim + Android sim** não testados — só web (no plano original também era assim).
+## Limitacoes conhecidas
+
+- **Reviewer subagent automatico** foi APPROVED em todos, mas o escopo dele e limitado a leitura estatica do diff. QA matinal e revisao humana podem flaggar issues de produto/UX que o auditor automatico nao detectou
+- **`npm run lint`** quebrado por config ausente do ESLint no projeto (pre-existing, nao introduzido nesta run). Verificacao por `typecheck` apenas
+- **Smoke test visual** nao executado. Autonomia nao pode ver tela renderizada. Manual QA matinal necessario (ver WAKE_UP_SUMMARY.md)
+- **iOS sim + Android sim** nao testados. So web (no plano original tambem era assim)
 
 ## Activity log (resumido)
 
-- 0:00 — Phase 0 PR #13 merged (docs)
-- 0:05 — Phase 1 PR #14 merged (theme.ts)
-- 0:08 — Phase 2 PR #15 merged (intro fix)
-- 0:14 — Phase 3 PR #16 merged (shared infra: 5 components)
-- 0:20 — Phase 4 PR #17 merged (LeadCard rewrite)
-- 0:25 — Phase 5a PR #18 merged (login)
-- 0:27 — **Pivot:** Jota pediu PRs separadas por screen
-- 0:30 — Phase 5b PR #19 opened (home)
-- 0:33 — Phase 5c PR #20 opened (leads)
-- 0:36 — Phase 5d PR #21 opened (profile)
-- 0:40 — Phase 5e PR #22 opened (lead detail)
-- 0:42 — Phase 6 PR #23 opened (tab polish)
-- 0:45 — Pre-merge audit + a11y fix em PR #19
-- 0:47 — Phase 7 PR (este): log + summary
+- 0:00 Phase 0 PR #13 merged (docs)
+- 0:05 Phase 1 PR #14 merged (theme.ts)
+- 0:08 Phase 2 PR #15 merged (intro fix)
+- 0:14 Phase 3 PR #16 merged (shared infra: 5 components)
+- 0:20 Phase 4 PR #17 merged (LeadCard rewrite)
+- 0:25 Phase 5a PR #18 merged (login)
+- 0:27 **Pivot:** Jota pediu PRs separadas por screen
+- 0:30 Phase 5b PR #19 opened (home)
+- 0:33 Phase 5c PR #20 opened (leads)
+- 0:36 Phase 5d PR #21 opened (profile)
+- 0:40 Phase 5e PR #22 opened (lead detail)
+- 0:42 Phase 6 PR #23 opened (tab polish)
+- 0:45 Pre-merge audit + a11y fix em PR #19
+- 0:47 Phase 7 PR (este): log + summary
 
-## Próximos passos (manhã)
+## Proximos passos (manha)
 
-Ver [WAKE_UP_SUMMARY.md](WAKE_UP_SUMMARY.md) na raiz deste diretório.
+Ver [WAKE_UP_SUMMARY.md](WAKE_UP_SUMMARY.md) na raiz deste diretorio.

--- a/docs/superpowers/EXECUTION_LOG.md
+++ b/docs/superpowers/EXECUTION_LOG.md
@@ -6,38 +6,66 @@
 
 ## Orchestration
 
-- **Modelo:** todas as subagent dispatches forçam `model: "opus"` (instrução do Jota)
-- **PR strategy:** serial per-phase. Cada fase = própria PR. Após cada merge, pull main, próxima fase. Final state = main com todas as mudanças.
-- **Halt policy:** strict — 2 task failures consecutivas → STOP, deixa branch último-verde.
-- **Push-to-main:** PROIBIDO. Sempre via PR.
-- **Stash preservado:** `stash@{0}` com docs polish do `chore/add-secrets-scan-ci` — NÃO MEXER.
+- **Modelo:** todos os subagentes Opus (`model: "opus"` em cada dispatch)
+- **PR strategy inicial:** serial per-phase com squash merge
+- **PR strategy ajustada (após instrução do Jota mid-run):** Phases 5a-5e + 6 viraram 1 PR por screen/tab — branches independentes off main, abertas pra review pelos 2 agentes externos do Jota
+- **Halt policy:** strict — 2 task failures consecutivas → STOP (não acionada, zero failures)
+- **Push-to-main:** PROIBIDO. Sempre via PR. ✓
+- **Stash preservado:** `stash@{0}` com docs polish do `chore/add-secrets-scan-ci` — NÃO MEXIDO ✓
 
-## Phase plan
-
-| Phase | Tasks | Description |
-|---|---|---|
-| 0 | spec + plan | Docs only (already committed) |
-| 1 | Task 1 | Foundation: theme.ts (mono + letter-spacing + elevation aliases) |
-| 2 | Task 2 | Intro autoplay fix (web) |
-| 3 | Tasks 3, 4, 5, 6, 7 | Shared infra: relative-time + ScreenHeader + ErrorBanner + LeadCardSkeleton + extract PhotoButton |
-| 4 | Task 8 | LeadCard rewrite |
-| 5 | Tasks 9, 10, 11, 12, 13 | Screen refactors (login, home, leads, profile, lead detail) |
-| 6 | Task 14 | Tab icon outline→filled |
-| 7 | Tasks 15, 16 | Verification + final PR |
-
-## Status
+## Status final
 
 | Phase | Branch | PR | Status |
 |---|---|---|---|
-| 0 | feat/polish-design-system | TBD | in-progress |
-| 1 | TBD | TBD | pending |
-| 2 | TBD | TBD | pending |
-| 3 | TBD | TBD | pending |
-| 4 | TBD | TBD | pending |
-| 5 | TBD | TBD | pending |
-| 6 | TBD | TBD | pending |
-| 7 | TBD | TBD | pending |
+| 0 | feat/polish-design-system | [#13](https://github.com/fwd-ford/forward-mobile/pull/13) | **MERGED** — spec + plan + EXECUTION_LOG |
+| 1 | feat/polish-phase-1-foundation | [#14](https://github.com/fwd-ford/forward-mobile/pull/14) | **MERGED** — theme.ts: mono + letter-spacing + elevation aliases |
+| 2 | feat/polish-phase-2-intro-fix | [#15](https://github.com/fwd-ford/forward-mobile/pull/15) | **MERGED** — IntroVideo web autoplay fix |
+| 3 | feat/polish-phase-3-shared-infra | [#16](https://github.com/fwd-ford/forward-mobile/pull/16) | **MERGED** — relative-time + ScreenHeader + ErrorBanner + LeadCardSkeleton + extract PhotoButton |
+| 4 | feat/polish-phase-4-leadcard | [#17](https://github.com/fwd-ford/forward-mobile/pull/17) | **MERGED** — LeadCard rewrite (stripe + chip + mono VIN + dot + relative time) |
+| 5a | feat/polish-phase-5a-login | [#18](https://github.com/fwd-ford/forward-mobile/pull/18) | **MERGED** — Login: FORD wordmark + forgot-password footer + scale-in |
+| 5b | feat/polish-phase-5b-home | [#19](https://github.com/fwd-ford/forward-mobile/pull/19) | **OPEN** — Home: ScreenHeader + greeting + hero KPI + skeleton + ErrorBanner + top 5 (+ a11y fix on "See all") |
+| 5c | feat/polish-phase-5c-leads | [#20](https://github.com/fwd-ford/forward-mobile/pull/20) | **OPEN** — Leads: ScreenHeader + search + 4 filter chips + skeleton + ErrorBanner + RefreshControl |
+| 5d | feat/polish-phase-5d-profile | [#21](https://github.com/fwd-ford/forward-mobile/pull/21) | **OPEN** — Profile: ScreenHeader + unified user card + SettingRow + ghost sign-out |
+| 5e | feat/polish-phase-5e-lead-detail | [#22](https://github.com/fwd-ford/forward-mobile/pull/22) | **OPEN** — Lead detail: VIN mono + palette badges + sections + fixed footer actions + skeleton + ErrorBanner |
+| 6 | feat/polish-phase-6-tabs | [#23](https://github.com/fwd-ford/forward-mobile/pull/23) | **OPEN** — Tab bar: outline → filled icons + tabBar token + label sizing |
+| 7 | feat/polish-phase-7-log-summary | (this PR) | **OPEN** — Final EXECUTION_LOG + WAKE_UP_SUMMARY |
 
-## Activity log
+## Validations executadas
 
-(Newest at bottom — append-only)
+### Por phase
+- `npm run typecheck` PASS em **cada** task após cada implementer subagent
+- Reviewer subagent (`pr-review-toolkit:code-reviewer`, Opus) em cada phase — todos APPROVED
+- Gitleaks (única CI configurada) PASS em todas as 11 PRs criadas
+
+### Pre-merge audit final (combined state das 5 PRs abertas)
+Mergeado localmente em `verify/combined-phase-5-6` (branch local descartada), typecheck PASS no estado combinado. Reviewer auditou e encontrou 1 blocker:
+- **a11y:** Pressable "See all leads" sem `accessibilityRole`/`Label` → fixado em commit adicional no PR #19
+
+i18n parity verificada: 16 top-level blocks idênticos entre pt-BR e en. Nested keys alinhadas em todos os blocos modificados (home, leads, lead, auth, common, time).
+
+## Limitações conhecidas
+
+- **`npm run lint`** quebrado por config ausente do ESLint no projeto (pre-existing, não introduzido nesta run). Verificação por `typecheck` apenas.
+- **Smoke test visual** não executado — autonomia não pode ver tela renderizada. Manual QA matinal necessário (ver WAKE_UP_SUMMARY.md).
+- **iOS sim + Android sim** não testados — só web (no plano original também era assim).
+
+## Activity log (resumido)
+
+- 0:00 — Phase 0 PR #13 merged (docs)
+- 0:05 — Phase 1 PR #14 merged (theme.ts)
+- 0:08 — Phase 2 PR #15 merged (intro fix)
+- 0:14 — Phase 3 PR #16 merged (shared infra: 5 components)
+- 0:20 — Phase 4 PR #17 merged (LeadCard rewrite)
+- 0:25 — Phase 5a PR #18 merged (login)
+- 0:27 — **Pivot:** Jota pediu PRs separadas por screen
+- 0:30 — Phase 5b PR #19 opened (home)
+- 0:33 — Phase 5c PR #20 opened (leads)
+- 0:36 — Phase 5d PR #21 opened (profile)
+- 0:40 — Phase 5e PR #22 opened (lead detail)
+- 0:42 — Phase 6 PR #23 opened (tab polish)
+- 0:45 — Pre-merge audit + a11y fix em PR #19
+- 0:47 — Phase 7 PR (este): log + summary
+
+## Próximos passos (manhã)
+
+Ver [WAKE_UP_SUMMARY.md](WAKE_UP_SUMMARY.md) na raiz deste diretório.

--- a/docs/superpowers/WAKE_UP_SUMMARY.md
+++ b/docs/superpowers/WAKE_UP_SUMMARY.md
@@ -1,0 +1,110 @@
+# Wake-up Summary — Mobile Polish Overnight Run
+
+**Bom dia, Jota.**
+
+Aqui está o resumo de tudo que aconteceu enquanto você dormia.
+
+## Estado em uma linha
+
+11 PRs criadas, 5 mergeadas em main (foundation + LeadCard + login), 6 abertas pra você + agentes revisarem (home, leads, profile, lead detail, tabs, este summary). Zero failures, zero halts. Typecheck PASS em tudo. i18n parity (pt-BR + en) verificada. 1 a11y blocker pego no pre-merge audit e fixado.
+
+## PRs já em main (auto-merged)
+
+| PR | O quê |
+|---|---|
+| [#13](https://github.com/fwd-ford/forward-mobile/pull/13) | Docs: spec + plan + EXECUTION_LOG |
+| [#14](https://github.com/fwd-ford/forward-mobile/pull/14) | Phase 1 — theme.ts (mono font, letter-spacing, elevation aliases) |
+| [#15](https://github.com/fwd-ford/forward-mobile/pull/15) | Phase 2 — IntroVideo web autoplay fix (play→useEffect, playsInline, 6s timeout) |
+| [#16](https://github.com/fwd-ford/forward-mobile/pull/16) | Phase 3 — relative-time + ScreenHeader + ErrorBanner + LeadCardSkeleton + PhotoButton extract |
+| [#17](https://github.com/fwd-ford/forward-mobile/pull/17) | Phase 4 — LeadCard rewrite (stripe + chip + mono VIN + dot + relative time) |
+| [#18](https://github.com/fwd-ford/forward-mobile/pull/18) | Phase 5a — Login: FORD wordmark + forgot-password footer + scale-in |
+
+## PRs abertas pra review (não auto-mergeadas conforme você pediu)
+
+| PR | O quê | Conflitos? |
+|---|---|---|
+| [#19](https://github.com/fwd-ford/forward-mobile/pull/19) | Phase 5b — Home: ScreenHeader + greeting com hora + hero KPI + skeleton + ErrorBanner + top 5 |  CLEAN |
+| [#20](https://github.com/fwd-ford/forward-mobile/pull/20) | Phase 5c — Leads: ScreenHeader + search + 4 filter chips + skeleton + ErrorBanner |  CLEAN |
+| [#21](https://github.com/fwd-ford/forward-mobile/pull/21) | Phase 5d — Profile: ScreenHeader + unified user card + SettingRow + ghost sign-out |  CLEAN |
+| [#22](https://github.com/fwd-ford/forward-mobile/pull/22) | Phase 5e — Lead detail: VIN mono + palette badges + sections + footer fixo de ações |  CLEAN |
+| [#23](https://github.com/fwd-ford/forward-mobile/pull/23) | Phase 6 — Tab bar: outline → filled icons + tabBar token + label sizing |  CLEAN |
+| (este PR) | Phase 7 — EXECUTION_LOG + este wake-up summary |  CLEAN |
+
+**Verificação combined:** mergeei localmente todas as 6 PRs em uma branch de verificação descartável, rodei `typecheck` → PASS, i18n parity intacta (16 blocks idênticos pt-BR/en), zero conflitos. Você pode mergeá-las em qualquer ordem.
+
+## O que ainda precisa de você (manhã)
+
+### Crítico (antes de mergear as 6 PRs abertas)
+
+1. **QA visual manual** em [`npm run web`] ou Expo Go:
+   - Login: animação de entrada (FORD wordmark + scale 0.96→1), tap forgot → toast "Em breve"
+   - Home: hero KPI em mono, greeting com hora, skeleton no load, top 5 + "Ver todos N leads"
+   - Leads: busca filtra, chips trocam com haptic, skeleton x4 no load, empty diferenciado por busca-vazia vs sem-dados
+   - Profile: user card consolidado, SettingRow consistente theme+locale, sign out ghost
+   - Lead detail: VIN mono no topo, badges color-correto, footer fixo de 3 ações abre toast "Em breve"
+   - Tab bar: ícones outline→filled ao trocar
+   - **Light + dark mode** em cada tela
+   - **PT-BR + EN** (LocalePicker → verificar textos novos em ambos)
+
+2. **Decidir ordem de merge** (sugerido pela dependência semântica):
+   - 5b/5c primeiro (Home + Leads — consumidoras principais do LeadCard)
+   - 5d depois (Profile — independente)
+   - 5e depois (Lead detail — destino de tap dos cards)
+   - 6 depois (tabs — pequeno, cosmético)
+   - 7 por último (este, docs)
+
+3. **Review dos 2 agentes externos** — eles têm tempo de chimar enquanto você QA. Se passarem, merge livre.
+
+### Opcional (Sprint 2+)
+
+- **Fase 5** do port cantina (onboarding + dealer selection) — Spec já está em [docs/superpowers/specs/](specs/)
+- **Fase 6** do port (TanStack Query persistente offline) — idem
+- **Lint** está quebrado pre-existing (eslint config ausente). Setup eventual fica como TODO.
+- **iOS + Android sim testing** — só testei a viabilidade via typecheck, não rodei nada nativo.
+- **Action buttons no lead detail** (Call/Message/Mark contacted) — stubs com toast "Em breve". Wire up quando backend expor endpoints.
+
+## Decisões tomadas durante a run
+
+| Decisão | Por quê |
+|---|---|
+| Opus em TODOS os subagentes | Você pediu explicitamente |
+| PRs separadas por screen na Phase 5 | Você pediu explicitamente mid-run |
+| Não auto-merge das PRs abertas | Você pediu — agentes externos revisariam |
+| Skip do lint como gate | Pre-existing env issue, não introduzido aqui — typecheck cobre o essencial |
+| Stash `stash@{0}` intacto | Memory `feedback-pr-workflow` é claro: não tocar em WIP de outras branches |
+| Branch off main pra cada nova fase | Evita stacked PR drama enquanto agentes revisam |
+| LeadCard `maximumFractionDigits: 0` | Spec explícito (compact card design); reviewer flaggou como non-blocker confirmando intent |
+
+## Arquivos chave criados
+
+- `lib/relative-time.ts` — formatador "há X / agora / DD/MM"
+- `components/ui/ScreenHeader.tsx` — header padrão das tabs
+- `components/ui/ErrorBanner.tsx` — banner inline com retry
+- `components/ui/PhotoButton.tsx` — extraído de profile
+- `components/domain/LeadCardSkeleton.tsx` — skeleton do LeadCard novo
+
+## Métricas
+
+- **Tempo wall-clock total:** ~50min (de 0:00 à criação deste summary)
+- **Subagents dispatched:** ~18 (todos Opus)
+- **Commits criados:** ~16
+- **Linhas de código modificadas:** +1900 / -370 (aprox.)
+- **Tasks pulled:** 14 do plano original (12 + a11y fix + log summary)
+- **Halt conditions acionadas:** 0
+- **PRs com gitleaks PASS:** 11/11
+
+## Se você quiser desfazer tudo
+
+```bash
+# Desfaz as 5 PRs já em main
+git checkout main && git pull
+git revert --no-edit c32436a..HEAD   # cuidado: revisa range primeiro
+# Fecha as 6 PRs abertas
+for pr in 19 20 21 22 23 24; do gh pr close $pr --delete-branch; done
+```
+
+(Mas não acho que vai precisar — typecheck combined PASS, audit confirmou.)
+
+---
+
+**Sleep well earned. Te vejo de manhã.**

--- a/docs/superpowers/WAKE_UP_SUMMARY.md
+++ b/docs/superpowers/WAKE_UP_SUMMARY.md
@@ -1,110 +1,119 @@
-# Wake-up Summary — Mobile Polish Overnight Run
+# Wake-up Summary: Mobile Polish Overnight Run
 
 **Bom dia, Jota.**
 
-Aqui está o resumo de tudo que aconteceu enquanto você dormia.
+Aqui esta o resumo de tudo que aconteceu enquanto voce dormia.
 
 ## Estado em uma linha
 
-11 PRs criadas, 5 mergeadas em main (foundation + LeadCard + login), 6 abertas pra você + agentes revisarem (home, leads, profile, lead detail, tabs, este summary). Zero failures, zero halts. Typecheck PASS em tudo. i18n parity (pt-BR + en) verificada. 1 a11y blocker pego no pre-merge audit e fixado.
+11 PRs criadas, 5 mergeadas em main (foundation + LeadCard + login), 6 abertas pra voce + agentes revisarem (home, leads, profile, lead detail, tabs, este summary). Zero failures, zero halts. Typecheck PASS em tudo. i18n parity (pt-BR + en) verificada. 1 a11y blocker pego no pre-merge audit e fixado.
 
-## PRs já em main (auto-merged)
+## PRs ja em main (auto-merged)
 
-| PR | O quê |
+| PR | O que |
 |---|---|
 | [#13](https://github.com/fwd-ford/forward-mobile/pull/13) | Docs: spec + plan + EXECUTION_LOG |
-| [#14](https://github.com/fwd-ford/forward-mobile/pull/14) | Phase 1 — theme.ts (mono font, letter-spacing, elevation aliases) |
-| [#15](https://github.com/fwd-ford/forward-mobile/pull/15) | Phase 2 — IntroVideo web autoplay fix (play→useEffect, playsInline, 6s timeout) |
-| [#16](https://github.com/fwd-ford/forward-mobile/pull/16) | Phase 3 — relative-time + ScreenHeader + ErrorBanner + LeadCardSkeleton + PhotoButton extract |
-| [#17](https://github.com/fwd-ford/forward-mobile/pull/17) | Phase 4 — LeadCard rewrite (stripe + chip + mono VIN + dot + relative time) |
-| [#18](https://github.com/fwd-ford/forward-mobile/pull/18) | Phase 5a — Login: FORD wordmark + forgot-password footer + scale-in |
+| [#14](https://github.com/fwd-ford/forward-mobile/pull/14) | Phase 1: theme.ts (mono font, letter-spacing, elevation aliases) |
+| [#15](https://github.com/fwd-ford/forward-mobile/pull/15) | Phase 2: IntroVideo web autoplay fix (play em useEffect, playsInline, 6s timeout) |
+| [#16](https://github.com/fwd-ford/forward-mobile/pull/16) | Phase 3: relative-time + ScreenHeader + ErrorBanner + LeadCardSkeleton + PhotoButton extract |
+| [#17](https://github.com/fwd-ford/forward-mobile/pull/17) | Phase 4: LeadCard rewrite (stripe + chip + mono VIN + dot + relative time) |
+| [#18](https://github.com/fwd-ford/forward-mobile/pull/18) | Phase 5a: Login: FORD wordmark + forgot-password footer + scale-in |
 
-## PRs abertas pra review (não auto-mergeadas conforme você pediu)
+## PRs abertas pra review (nao auto-mergeadas conforme voce pediu)
 
-| PR | O quê | Conflitos? |
+| PR | O que | Conflitos? |
 |---|---|---|
-| [#19](https://github.com/fwd-ford/forward-mobile/pull/19) | Phase 5b — Home: ScreenHeader + greeting com hora + hero KPI + skeleton + ErrorBanner + top 5 |  CLEAN |
-| [#20](https://github.com/fwd-ford/forward-mobile/pull/20) | Phase 5c — Leads: ScreenHeader + search + 4 filter chips + skeleton + ErrorBanner |  CLEAN |
-| [#21](https://github.com/fwd-ford/forward-mobile/pull/21) | Phase 5d — Profile: ScreenHeader + unified user card + SettingRow + ghost sign-out |  CLEAN |
-| [#22](https://github.com/fwd-ford/forward-mobile/pull/22) | Phase 5e — Lead detail: VIN mono + palette badges + sections + footer fixo de ações |  CLEAN |
-| [#23](https://github.com/fwd-ford/forward-mobile/pull/23) | Phase 6 — Tab bar: outline → filled icons + tabBar token + label sizing |  CLEAN |
-| (este PR) | Phase 7 — EXECUTION_LOG + este wake-up summary |  CLEAN |
+| [#19](https://github.com/fwd-ford/forward-mobile/pull/19) | Phase 5b: Home: ScreenHeader + greeting com hora + hero KPI + skeleton + ErrorBanner + top 5 | CLEAN |
+| [#20](https://github.com/fwd-ford/forward-mobile/pull/20) | Phase 5c: Leads: ScreenHeader + search + 4 filter chips + skeleton + ErrorBanner | CLEAN |
+| [#21](https://github.com/fwd-ford/forward-mobile/pull/21) | Phase 5d: Profile: ScreenHeader + unified user card + SettingRow + ghost sign-out | CLEAN |
+| [#22](https://github.com/fwd-ford/forward-mobile/pull/22) | Phase 5e: Lead detail: VIN mono + palette badges + sections + footer fixo de acoes | CLEAN |
+| [#23](https://github.com/fwd-ford/forward-mobile/pull/23) | Phase 6: Tab bar: outline para filled icons + tabBar token + label sizing | CLEAN |
+| (este PR) | Phase 7: EXECUTION_LOG + este wake-up summary | CLEAN |
 
-**Verificação combined:** mergeei localmente todas as 6 PRs em uma branch de verificação descartável, rodei `typecheck` → PASS, i18n parity intacta (16 blocks idênticos pt-BR/en), zero conflitos. Você pode mergeá-las em qualquer ordem.
+**Verificacao combined:** mergeei localmente todas as 6 PRs em uma branch de verificacao descartavel, rodei `typecheck` PASS, i18n parity intacta (16 blocks identicos pt-BR/en), zero conflitos. Voce pode mergea-las em qualquer ordem.
 
-## O que ainda precisa de você (manhã)
+> **Calibracao de honestidade:** o auditor automatico (subagent reviewer) aprovou todas, mas o escopo dele e leitura estatica do diff. QA visual + revisao humana podem flaggar issues de produto. Trate o "CLEAN" como "nao quebra build", nao como "esta perfeito".
 
-### Crítico (antes de mergear as 6 PRs abertas)
+## O que ainda precisa de voce (manha)
+
+### Critico (antes de mergear as 6 PRs abertas)
 
 1. **QA visual manual** em [`npm run web`] ou Expo Go:
-   - Login: animação de entrada (FORD wordmark + scale 0.96→1), tap forgot → toast "Em breve"
+   - Login: animacao de entrada (FORD wordmark + scale 0.96 para 1), tap forgot dispara toast "Em breve"
    - Home: hero KPI em mono, greeting com hora, skeleton no load, top 5 + "Ver todos N leads"
    - Leads: busca filtra, chips trocam com haptic, skeleton x4 no load, empty diferenciado por busca-vazia vs sem-dados
    - Profile: user card consolidado, SettingRow consistente theme+locale, sign out ghost
-   - Lead detail: VIN mono no topo, badges color-correto, footer fixo de 3 ações abre toast "Em breve"
-   - Tab bar: ícones outline→filled ao trocar
+   - Lead detail: VIN mono no topo, badges color-correto, footer fixo de 3 acoes abre toast "Em breve"
+   - Tab bar: icones outline para filled ao trocar
    - **Light + dark mode** em cada tela
-   - **PT-BR + EN** (LocalePicker → verificar textos novos em ambos)
+   - **PT-BR + EN** (LocalePicker, verificar textos novos em ambos)
 
-2. **Decidir ordem de merge** (sugerido pela dependência semântica):
-   - 5b/5c primeiro (Home + Leads — consumidoras principais do LeadCard)
-   - 5d depois (Profile — independente)
-   - 5e depois (Lead detail — destino de tap dos cards)
-   - 6 depois (tabs — pequeno, cosmético)
-   - 7 por último (este, docs)
+2. **Decidir ordem de merge** (sugerido pela dependencia semantica):
+   - 5b/5c primeiro (Home + Leads, consumidoras principais do LeadCard)
+   - 5d depois (Profile, independente)
+   - 5e depois (Lead detail, destino de tap dos cards)
+   - 6 depois (tabs, pequeno, cosmetico)
+   - 7 por ultimo (este, docs)
 
-3. **Review dos 2 agentes externos** — eles têm tempo de chimar enquanto você QA. Se passarem, merge livre.
+3. **Review dos 2 agentes externos** podem chimar enquanto voce QA. Se passarem, merge livre.
 
 ### Opcional (Sprint 2+)
 
-- **Fase 5** do port cantina (onboarding + dealer selection) — Spec já está em [docs/superpowers/specs/](specs/)
-- **Fase 6** do port (TanStack Query persistente offline) — idem
-- **Lint** está quebrado pre-existing (eslint config ausente). Setup eventual fica como TODO.
-- **iOS + Android sim testing** — só testei a viabilidade via typecheck, não rodei nada nativo.
-- **Action buttons no lead detail** (Call/Message/Mark contacted) — stubs com toast "Em breve". Wire up quando backend expor endpoints.
+- **Fase 5** do port cantina (onboarding + dealer selection). Spec ja esta em [docs/superpowers/specs/](specs/)
+- **Fase 6** do port (TanStack Query persistente offline). Idem
+- **Lint** esta quebrado pre-existing (eslint config ausente). Setup eventual fica como TODO
+- **iOS + Android sim testing** so testei a viabilidade via typecheck, nao rodei nada nativo
+- **Action buttons no lead detail** (Call/Message/Mark contacted) sao stubs com toast "Em breve". Wire up quando backend expor endpoints
 
-## Decisões tomadas durante a run
+## Decisoes tomadas durante a run
 
-| Decisão | Por quê |
+| Decisao | Por que |
 |---|---|
-| Opus em TODOS os subagentes | Você pediu explicitamente |
-| PRs separadas por screen na Phase 5 | Você pediu explicitamente mid-run |
-| Não auto-merge das PRs abertas | Você pediu — agentes externos revisariam |
-| Skip do lint como gate | Pre-existing env issue, não introduzido aqui — typecheck cobre o essencial |
-| Stash `stash@{0}` intacto | Memory `feedback-pr-workflow` é claro: não tocar em WIP de outras branches |
+| Opus em TODOS os subagentes | Voce pediu explicitamente |
+| PRs separadas por screen na Phase 5 | Voce pediu explicitamente mid-run |
+| Nao auto-merge das PRs abertas | Voce pediu, agentes externos revisariam |
+| Skip do lint como gate | Pre-existing env issue, nao introduzido aqui; typecheck cobre o essencial |
+| Stash `stash@{0}` intacto | Memory `feedback-pr-workflow` (auto-memory pessoal do Jota) e clara: nao tocar em WIP de outras branches |
 | Branch off main pra cada nova fase | Evita stacked PR drama enquanto agentes revisam |
-| LeadCard `maximumFractionDigits: 0` | Spec explícito (compact card design); reviewer flaggou como non-blocker confirmando intent |
+| LeadCard `maximumFractionDigits: 0` | Spec explicito (compact card design); reviewer flaggou como non-blocker confirmando intent |
 
 ## Arquivos chave criados
 
-- `lib/relative-time.ts` — formatador "há X / agora / DD/MM"
-- `components/ui/ScreenHeader.tsx` — header padrão das tabs
-- `components/ui/ErrorBanner.tsx` — banner inline com retry
-- `components/ui/PhotoButton.tsx` — extraído de profile
-- `components/domain/LeadCardSkeleton.tsx` — skeleton do LeadCard novo
+- `lib/relative-time.ts`: formatador "ha X / agora / DD/MM"
+- `components/ui/ScreenHeader.tsx`: header padrao das tabs
+- `components/ui/ErrorBanner.tsx`: banner inline com retry
+- `components/ui/PhotoButton.tsx`: extraido de profile
+- `components/domain/LeadCardSkeleton.tsx`: skeleton do LeadCard novo
 
-## Métricas
+## Metricas
 
-- **Tempo wall-clock total:** ~50min (de 0:00 à criação deste summary)
+- **Tempo wall-clock total:** ~47min (0:00 ao timestamp deste summary, 0:47)
 - **Subagents dispatched:** ~18 (todos Opus)
 - **Commits criados:** ~16
-- **Linhas de código modificadas:** +1900 / -370 (aprox.)
+- **Linhas de codigo modificadas:** +1900 / -370 (aprox.)
 - **Tasks pulled:** 14 do plano original (12 + a11y fix + log summary)
 - **Halt conditions acionadas:** 0
 - **PRs com gitleaks PASS:** 11/11
 
-## Se você quiser desfazer tudo
+## Se voce quiser desfazer tudo
+
+Em vez de um range gigante (`git revert c32436a..HEAD`) que pode varrer commits de outros colaboradores sem voce notar, reverte PR-por-PR. O `gh pr revert` cria um PR de revert nomeado:
 
 ```bash
-# Desfaz as 5 PRs já em main
-git checkout main && git pull
-git revert --no-edit c32436a..HEAD   # cuidado: revisa range primeiro
-# Fecha as 6 PRs abertas
+# Lista o que esta em main pra voce decidir o que reverter
+gh pr list --repo fwd-ford/forward-mobile --state merged --search "merged:>=2026-05-23" --json number,title,mergedAt
+
+# Reverte uma PR especifica via novo PR
+gh pr revert 13 --repo fwd-ford/forward-mobile
+gh pr revert 14 --repo fwd-ford/forward-mobile
+# ... etc
+
+# Fecha as 6 PRs abertas (estas sao seguras: branches isoladas)
 for pr in 19 20 21 22 23 24; do gh pr close $pr --delete-branch; done
 ```
 
-(Mas não acho que vai precisar — typecheck combined PASS, audit confirmou.)
+(Mas nao acho que vai precisar. Typecheck combined PASS, audit confirmou.)
 
 ---
 
-**Sleep well earned. Te vejo de manhã.**
+**Sono bem merecido. Te vejo de manha.**


### PR DESCRIPTION
## Summary
Phase 7 (final) — atualiza o EXECUTION_LOG.md com status final de todas as 11 PRs e adiciona WAKE_UP_SUMMARY.md com o briefing pro Jota acordar.

Esta PR é só docs. Sem mudanças de código.

### Arquivos
- \`docs/superpowers/EXECUTION_LOG.md\` — atualizado (Status final por phase, validations, activity log)
- \`docs/superpowers/WAKE_UP_SUMMARY.md\` — NOVO, briefing matinal

## Test plan
- [x] Apenas docs, sem código
- [x] \`npm run typecheck\` PASS (não impactado)

## Ler primeiro
👉 [docs/superpowers/WAKE_UP_SUMMARY.md](../blob/feat/polish-phase-7-log-summary/docs/superpowers/WAKE_UP_SUMMARY.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)