### PR TITLE
fix(ui): ErrorBanner retry button >=44pt touch target

### DIFF
--- a/components/ui/ErrorBanner.tsx
+++ b/components/ui/ErrorBanner.tsx
@@ -90,12 +90,15 @@ function createStyles(c: ThemeColors) {
       fontWeight: "600",
     },
     retry: {
-      paddingVertical: spacing.xs,
-      paddingHorizontal: spacing.sm,
+      minHeight: 44,
+      paddingVertical: spacing.sm + 2,
+      paddingHorizontal: spacing.md,
       borderRadius: radius.sm,
       backgroundColor: c.surface,
       borderWidth: 1,
       borderColor: c.error,
+      alignItems: "center",
+      justifyContent: "center",
     },
     retryLabel: {
       ...typography.caption,


### PR DESCRIPTION
## Summary
Fix do P0-3 documentado em [UX_QA_REPORT.md](../blob/docs/ux-qa-report/docs/superpowers/UX_QA_REPORT.md): botao "Tentar de novo" media 110x28 (Playwright measurement), viola regra de 44pt do CLAUDE.md.

### Mudancas em components/ui/ErrorBanner.tsx
- paddingVertical: xs(4) -> sm+2(10)
- paddingHorizontal: sm(8) -> md(12)
- + minHeight: 44 explicito
- + alignItems/justifyContent center pra garantir mesmo se children mudarem

### Impacto
3 telas que usam ErrorBanner (Home, Leads, Lead detail) ganham retry button toc-friendly.

## Test plan
- [x] npm run typecheck PASS
- [ ] Manual: rodar Playwright + measureTouchTargets, confirmar w>=44 e h>=44

Bot Generated with [Claude Code](https://claude.com/claude-code)