### PR TITLE
fix(infra): web locale detection + Ionicons font preload [P0-1, P0-2]

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,3 +1,5 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useFonts } from "expo-font";
 import { Stack, useRouter, useSegments } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -27,6 +29,9 @@ function RootStack() {
   const [introDone, setIntroDone] = useState(false);
   const [ready, setReady] = useState(false);
   const [session, setSession] = useState<Session | null>(null);
+  // Preload Ionicons so the first paint never shows empty glyph squares (FOIT).
+  // Pre-carrega Ionicons; sem isso, primeiro paint mostra quadrados vazios.
+  const [fontsLoaded] = useFonts(Ionicons.font);
 
   // Auth check runs in parallel with the intro — whichever finishes later unblocks the router.
   // Verificacao de sessao roda em paralelo com a intro — o mais lento destrava o router.
@@ -46,7 +51,7 @@ function RootStack() {
       <StatusBar style={mode === "dark" ? "light" : "dark"} />
       {!introDone ? (
         <IntroVideo onFinished={() => setIntroDone(true)} />
-      ) : !ready || !themeHydrated ? null : (
+      ) : !ready || !themeHydrated || !fontsLoaded ? null : (
         <Stack
           screenOptions={{
             headerStyle: { backgroundColor: colors.bg },

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -16,11 +16,20 @@ import ptBR from "./pt-BR.json";
 /** Reads the device locale and maps it onto a supported Locale, defaulting to pt-BR. */
 export function detectDeviceLocale(): Locale {
   try {
-    const tag =
-      Platform.OS === "ios"
-        ? NativeModules.SettingsManager?.settings?.AppleLocale ??
-          NativeModules.SettingsManager?.settings?.AppleLanguages?.[0]
-        : NativeModules.I18nManager?.localeIdentifier;
+    // Web does not expose NativeModules; navigator.language is the canonical source.
+    // No web NativeModules nao existe; navigator.language e a fonte canonica.
+    let tag: string | undefined;
+    if (Platform.OS === "web") {
+      if (typeof navigator !== "undefined") {
+        tag = navigator.language ?? navigator.languages?.[0];
+      }
+    } else if (Platform.OS === "ios") {
+      tag =
+        NativeModules.SettingsManager?.settings?.AppleLocale ??
+        NativeModules.SettingsManager?.settings?.AppleLanguages?.[0];
+    } else {
+      tag = NativeModules.I18nManager?.localeIdentifier;
+    }
     if (typeof tag !== "string") return "pt-BR";
     const normalized = tag.replace("_", "-");
     if (isLocale(normalized)) return normalized;


### PR DESCRIPTION
## Summary

Fecha dois P0s cross-cutting do [UX_QA_REPORT.md](docs/superpowers/UX_QA_REPORT.md):

- **P0-1 — Locale web quebrada:** `detectDeviceLocale` so lia `NativeModules.SettingsManager` / `NativeModules.I18nManager`, que sao `undefined` no web. Agora le `navigator.language` primeiro quando `Platform.OS === "web"`.
- **P0-2 — Ionicons FOIT:** todos os icones renderizavam como quadrados vazios por 500-1500ms ate `Ionicons.ttf` carregar. Pre-carrega via `useFonts(Ionicons.font)` e gateia o render do Stack ate `fontsLoaded`.

## Test plan

- [x] `npx tsc --noEmit` zero erros
- [ ] Manual: abrir web build em incognito com idioma do navegador EN, confirmar UI em EN no primeiro paint
- [ ] Manual: cold start no web, confirmar zero quadrados vazios no lugar dos icones

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>