### PR TITLE
polish(login): Button loadingLabel + Toast SafeArea + forgot password message

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -105,7 +105,7 @@ export default function LoginScreen() {
     haptic.light();
     setToast({
       visible: true,
-      message: t("common.coming_soon"),
+      message: t("auth.forgot_help"),
       variant: "info",
     });
   }
@@ -177,6 +177,7 @@ export default function LoginScreen() {
 
           <Button
             label={t("auth.sign_in")}
+            loadingLabel={t("auth.signing_in")}
             loading={loading}
             disabled={buttonDisabled}
             onPress={onSubmit}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -17,12 +17,15 @@ export interface ButtonProps extends Omit<PressableProps, "children"> {
   label: string;
   variant?: Variant;
   loading?: boolean;
+  /** Optional label shown next to the spinner while loading. Falls back to spinner-only when omitted. */
+  loadingLabel?: string;
 }
 
 export function Button({
   label,
   variant = "primary",
   loading,
+  loadingLabel,
   disabled,
   style,
   ...rest
@@ -77,7 +80,14 @@ export function Button({
         ]}
       >
         {loading ? (
-          <ActivityIndicator color={indicatorColor} />
+          loadingLabel ? (
+            <>
+              <ActivityIndicator color={indicatorColor} style={styles.spinnerInline} />
+              <Text style={labelStyle}>{loadingLabel}</Text>
+            </>
+          ) : (
+            <ActivityIndicator color={indicatorColor} />
+          )
         ) : (
           <Text style={labelStyle}>{label}</Text>
         )}
@@ -92,10 +102,14 @@ function createStyles(c: ThemeColors) {
       height: 48,
       paddingHorizontal: spacing.lg,
       borderRadius: radius.md,
+      flexDirection: "row",
       alignItems: "center",
       justifyContent: "center",
       borderWidth: 1,
       borderColor: "transparent",
+    },
+    spinnerInline: {
+      marginRight: spacing.sm,
     },
     primary: { backgroundColor: c.primary, borderColor: c.primary },
     secondary: { backgroundColor: c.surface, borderColor: c.border },

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useEffect, useMemo, useRef } from "react";
 import { Animated, StyleSheet, Text } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useTheme } from "@/context/ThemeContext";
 import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
@@ -25,6 +26,7 @@ export function Toast({
   duration = 2500,
 }: ToastProps) {
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const translateY = useRef(new Animated.Value(ENTER_OFFSET)).current;
   const opacity = useRef(new Animated.Value(0)).current;
@@ -84,11 +86,16 @@ export function Toast({
       pointerEvents="none"
       style={[
         styles.container,
-        { borderLeftColor: accent, opacity, transform: [{ translateY }] },
+        {
+          top: insets.top + spacing.sm,
+          borderLeftColor: accent,
+          opacity,
+          transform: [{ translateY }],
+        },
       ]}
     >
       <Ionicons name={iconName} size={20} color={accent} />
-      <Text style={styles.message} numberOfLines={2}>
+      <Text style={styles.message} numberOfLines={3}>
         {message}
       </Text>
     </Animated.View>
@@ -99,7 +106,6 @@ function createStyles(c: ThemeColors) {
   return StyleSheet.create({
     container: {
       position: "absolute",
-      top: 60,
       left: spacing.xl,
       right: spacing.xl,
       flexDirection: "row",
@@ -108,14 +114,16 @@ function createStyles(c: ThemeColors) {
       paddingVertical: spacing.md,
       paddingHorizontal: spacing.lg,
       borderRadius: radius.md,
+      borderWidth: 1,
+      borderColor: c.border,
       borderLeftWidth: 3,
       backgroundColor: c.surface,
       zIndex: 1000,
-      elevation: 8,
+      elevation: 10,
       shadowColor: "#000",
-      shadowOpacity: 0.2,
-      shadowRadius: 12,
-      shadowOffset: { width: 0, height: 4 },
+      shadowOpacity: 0.28,
+      shadowRadius: 16,
+      shadowOffset: { width: 0, height: 6 },
     },
     message: {
       flex: 1,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -13,8 +13,10 @@
     "password": "Password",
     "subtitle": "Welcome. Sign in to access your leads.",
     "loading": "Loading",
+    "signing_in": "Signing in...",
     "error": "Could not sign in. Check your credentials.",
-    "forgot_password": "Forgot password"
+    "forgot_password": "Forgot password",
+    "forgot_help": "Coming soon. For now, ask your admin to reset it."
   },
   "tabs": {
     "home": "Home",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -17,8 +17,10 @@
     "password": "Senha",
     "subtitle": "Bem-vindo. Entre para acessar seus leads.",
     "loading": "Carregando",
+    "signing_in": "Entrando...",
     "error": "Nao foi possivel entrar. Verifique suas credenciais.",
-    "forgot_password": "Esqueci minha senha"
+    "forgot_password": "Esqueci minha senha",
+    "forgot_help": "Em breve. Por enquanto, peca um reset ao seu admin."
   },
   "tabs": {
     "home": "Inicio",


### PR DESCRIPTION
## Summary

Tela **Login** polida com 3 itens do [UX_QA_REPORT.md](docs/superpowers/UX_QA_REPORT.md):

- **P1-1** — `Button` agora aceita `loadingLabel?: string`. Quando presente + `loading=true`, renderiza spinner inline + texto em vez de spinner mudo. CTA `Entrar` agora mostra `Entrando...` / `Signing in...` durante o submit.
- **P1-5** — `Toast` agora se posiciona via `useSafeAreaInsets().top + spacing.sm` (era `top: 60` hardcoded). Ganhou borda 1px sutil + sombra mais forte (`elevation: 10`, opacity 0.28) pra ficar visivel ancorado no dark mode em vez de sumir no bg.
- **P1-6** — Mensagem de \"Esqueci minha senha\" trocou de generico `Em breve` pra acionavel `Em breve. Por enquanto, peca um reset ao seu admin.` (multi-linha, 3 rows).

## Test plan

- [x] `npx tsc --noEmit` zero erros
- [ ] Manual: tocar Entrar com creds validas — confirmar `Entrando...` aparece com spinner inline
- [ ] Manual: dark mode, tocar Esqueci minha senha — toast deve renderizar com borda + sombra visiveis no topo seguro
- [ ] Manual: web + native — toast deve subir do offset -120 e cair em `safeArea.top + 8px`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>