### PR TITLE
polish(home): mono web stack + hero hides on error + capitalized name + fullscreen error state

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
 import { LeadCardSkeleton } from "@/components/domain/LeadCardSkeleton";
+import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
@@ -92,7 +93,10 @@ export default function HomeScreen() {
       }
       const auth = await supabase.auth.getUser();
       const email = auth.data.user?.email;
-      if (email) setName(email.split("@")[0]);
+      if (email) {
+        const prefix = email.split("@")[0];
+        setName(prefix.charAt(0).toUpperCase() + prefix.slice(1));
+      }
     })();
   }, []);
 
@@ -128,19 +132,31 @@ export default function HomeScreen() {
         <View>
           <ScreenHeader title={t("home.today")} subtitle={greeting.trim()} />
 
-          <Card style={styles.hero}>
-            <View style={styles.heroCol}>
-              <Text style={styles.heroLabel}>{t("home.hero.active_leads")}</Text>
-              <Text style={styles.heroValue}>{hero.activeLeads}</Text>
-            </View>
-            <View style={styles.heroDivider} />
-            <View style={styles.heroCol}>
-              <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
-              <Text style={styles.heroValue}>{formatBRL(hero.pipelineBRL, { compact: true })}</Text>
-            </View>
-          </Card>
+          {/*
+            Hero hides on initial error with no cached leads: rendering "0 / R$ 0"
+            mid-error reads as real numbers and panics the user. Once any data
+            arrived (e.g. refresh-after-success), keep it visible even if a later
+            refresh errors so stale-but-useful beats blank.
+            Hero some no erro inicial sem leads: "0 / R$ 0" parece dado real e
+            assusta. Com dados em cache, mantem mesmo num erro de refresh.
+          */}
+          {!(error && leads.length === 0) ? (
+            <Card style={styles.hero}>
+              <View style={styles.heroCol}>
+                <Text style={styles.heroLabel}>{t("home.hero.active_leads")}</Text>
+                <Text style={styles.heroValue}>{hero.activeLeads}</Text>
+              </View>
+              <View style={styles.heroDivider} />
+              <View style={styles.heroCol}>
+                <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
+                <Text style={styles.heroValue}>{formatBRL(hero.pipelineBRL, { compact: true })}</Text>
+              </View>
+            </Card>
+          ) : null}
 
-          {error ? <ErrorBanner message={error} onRetry={() => void load()} /> : null}
+          {error && leads.length > 0 ? (
+            <ErrorBanner message={error} onRetry={() => void load()} />
+          ) : null}
 
           {initialLoading ? (
             <View style={styles.skeletonStack}>
@@ -152,12 +168,27 @@ export default function HomeScreen() {
         </View>
       }
       ListEmptyComponent={
-        !initialLoading && !error ? (
-          <EmptyState
-            icon="briefcase-outline"
-            title={t("home.empty_title")}
-            description={t("home.empty_description")}
-          />
+        !initialLoading ? (
+          error ? (
+            <EmptyState
+              icon="cloud-offline-outline"
+              title={t("home.error_title")}
+              description={error}
+              action={
+                <Button
+                  label={t("common.retry")}
+                  variant="secondary"
+                  onPress={() => void load()}
+                />
+              }
+            />
+          ) : (
+            <EmptyState
+              icon="briefcase-outline"
+              title={t("home.empty_title")}
+              description={t("home.empty_description")}
+            />
+          )
         ) : null
       }
       ListFooterComponent={

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -32,6 +32,7 @@
     "empty_title": "No leads yet",
     "empty_description": "When new leads are assigned to you, they will show up here.",
     "error": "Failed to load data",
+    "error_title": "Cannot reach the server",
     "hero": {
       "active_leads": "Active leads",
       "pipeline": "Pipeline"

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -36,6 +36,7 @@
     "empty_title": "Sem leads por enquanto",
     "empty_description": "Quando novos leads forem atribuidos a voce, eles aparecem aqui.",
     "error": "Falha ao carregar dados",
+    "error_title": "Sem conexao com o servidor",
     "hero": {
       "active_leads": "Leads ativos",
       "pipeline": "Pipeline"

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -106,10 +106,15 @@ export const fontFamily = {
   semibold: "System",
   bold: "System",
   extrabold: "System",
+  // Web fallback list ordered for legibility on Windows/macOS/Linux: native
+  // monos first, then bundled-with-Windows Cascadia/Consolas. Bare "ui-monospace"
+  // collapsed to a chunky serif on Windows.
+  // Stack ordenada por sistema: Windows nao tem SF Mono, entao precisa de Cascadia/Consolas.
   mono: Platform.select({
     ios: "Menlo",
     android: "monospace",
-    default: "ui-monospace",
+    default:
+      'ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", "Consolas", "Liberation Mono", Menlo, monospace',
   }) as string,
 } as const;
 


### PR DESCRIPTION
## Summary

Tela **Home** polida com 4 itens do [UX_QA_REPORT.md](docs/superpowers/UX_QA_REPORT.md):

- **P0-4 — Mono font web stack** ([lib/theme.ts](lib/theme.ts)): adicionado fallback robusto (\`SF Mono\` -> JetBrains -> Cascadia -> Consolas -> Menlo). Windows web nao tem SF Mono e estava caindo em serif chunky tipo Courier.
- **P0-5 — Hero esconde no erro inicial** ([app/(tabs)/index.tsx](app/(tabs)/index.tsx)): quando \`error && leads.length === 0\`, o card de Leads ativos / Pipeline nao renderiza. Mostrar \"0 / R\$ 0\" mid-erro fazia o vendedor achar que perdeu tudo. Refresh-com-erro mantem hero antigo (stale-but-useful).
- **P1-2 — Capitalize email prefix**: \`admin\` virou \`Admin\` no greeting fallback quando nao ha profile.full_name.
- **P1-4 — Fullscreen EmptyState no erro**: substituida a area cinza vazia abaixo do ErrorBanner por um EmptyState fullscreen com icone \`cloud-offline-outline\` + Button de retry. Hick's Law: uma acao clara beats nothing.

## Deferred

- **P1-3 (SafeArea ScreenHeader)**: deferido pra PR separado porque mexe em 3 telas (Home/Leads/Profile). Vou faze-lo depois que os 3 polishes individuais merge ar em.

## Test plan

- [x] \`npx tsc --noEmit\` zero erros
- [ ] Manual: backend offline, abrir Home — confirmar EmptyState fullscreen com retry, sem hero \"0/R\$ 0\"
- [ ] Manual: backend online, refresh-com-erro depois de carga ok — hero permanece com dados antigos + ErrorBanner aparece
- [ ] Manual: login com email sem profile.full_name — greeting deve ser \"Boa tarde, Admin\" (nao \"admin\")
- [ ] Manual web Windows: confirmar hero KPI \"0\" / \"R\$ 0\" renderiza em mono nitido, nao serif

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>