### PR TITLE
polish(leads): explicit zero plural form (no more '0 ativo')

### DIFF
--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -144,7 +144,9 @@ export default function LeadsScreen() {
         subtitle={
           isFiltering
             ? t("leads.subtitle_showing", { showing: filtered.length, total: activeCount })
-            : t("leads.subtitle_count", { count: activeCount })
+            : activeCount === 0
+              ? t("leads.subtitle_count_zero")
+              : t("leads.subtitle_count", { count: activeCount })
         }
       />
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,6 +72,7 @@
   },
   "leads": {
     "title": "Leads",
+    "subtitle_count_zero": "None active",
     "subtitle_count_one": "{{count}} active",
     "subtitle_count_other": "{{count}} active",
     "subtitle_showing": "Showing {{showing}} of {{total}}",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -76,6 +76,7 @@
   },
   "leads": {
     "title": "Leads",
+    "subtitle_count_zero": "Nenhum ativo",
     "subtitle_count_one": "{{count}} ativo",
     "subtitle_count_other": "{{count}} ativos",
     "subtitle_showing": "Mostrando {{showing}} de {{total}}",


### PR DESCRIPTION
## Summary

Tela **Leads** polida com 1 item do [UX_QA_REPORT.md](docs/superpowers/UX_QA_REPORT.md):

- **P1-8 — Plural com zero**: o subtitle de Leads mostrava \`0 ativo\` (singular) porque CLDR PT-BR trata 0 como \`one\`. Adicionada chave explicita \`subtitle_count_zero\` (\`Nenhum ativo\` / \`None active\`) e branch de \`activeCount === 0\` no screen, sem depender do fallback do CLDR.

## Test plan

- [x] \`npx tsc --noEmit\` zero erros
- [ ] Manual: backend offline (zero leads) — subtitle deve mostrar \`Nenhum ativo\`
- [ ] Manual: backend online com 1 lead ativo — subtitle deve mostrar \`1 ativo\`
- [ ] Manual: backend online com 2+ leads ativos — subtitle deve mostrar \`N ativos\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>