### PR TITLE
polish(profile): Switch accent on web + dark mode label semantics

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,6 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -211,7 +212,12 @@ export default function ProfileScreen() {
 
         <SettingRow
           icon={mode === "dark" ? "moon" : "sunny"}
-          label={mode === "dark" ? t("profile.dark_mode") : t("profile.light_mode")}
+          // Label always describes what the switch CONTROLS ("Dark mode"); the
+          // value line tells you the current setting. Previously the label
+          // mirrored the current mode and reading "Modo claro" + switch OFF
+          // sounded like "turning off light mode" — accidental coincidence.
+          // Label sempre descreve o que o switch controla; value mostra o estado.
+          label={t("profile.dark_mode")}
           value={isOverridden ? t("profile.theme_manual") : t("profile.theme_auto")}
           emphasis="label"
           right={
@@ -221,6 +227,14 @@ export default function ProfileScreen() {
               trackColor={{ false: colors.borderStrong, true: colors.primary }}
               thumbColor="#FFFFFF"
               ios_backgroundColor={colors.borderStrong}
+              // react-native-web ignores trackColor on the rendered <input type="checkbox">.
+              // accentColor is the native CSS property browsers honor for form-control tint.
+              // No web o trackColor nao se aplica; accentColor e o property CSS que pinta.
+              style={
+                Platform.OS === "web"
+                  ? ({ accentColor: colors.primary } as never)
+                  : undefined
+              }
             />
           }
         />


### PR DESCRIPTION
## Summary

Tela **Profile** polida com 2 itens do [UX_QA_REPORT.md](docs/superpowers/UX_QA_REPORT.md):

- **P0-6 — Switch trackColor honra Ford Blue no web**: \`react-native-web\` ignora a prop \`trackColor\` no \`<input type=\"checkbox\">\` renderizado e cai no accent default do browser (teal/verde). Adicionada style inline com \`accentColor\` (CSS) quando \`Platform.OS === \"web\"\`. Switch agora acende Ford Blue em todos os ambientes.
- **P1-7 — Label sempre \"Modo escuro\"**: o SettingRow do tema mostrava o modo ATUAL no label (\`Modo claro\` quando light, \`Modo escuro\` quando dark). Era confuso: \`Modo claro\` + switch OFF parecia \"desativando o modo claro\" — semantica certa so por acidente. Agora label e fixo, value continua descrevendo o estado (\`Seguindo o sistema\` / \`Override manual\`).

## Test plan

- [x] \`npx tsc --noEmit\` zero erros
- [ ] Manual web (light + dark): tocar Switch — track deve acender em Ford Blue
- [ ] Manual native iOS/Android: comportamento inalterado (RN ja respeita trackColor)
- [ ] Manual: trocar entre light/dark — label permanece \`Modo escuro\`, value alterna entre \`Seguindo o sistema\` e \`Override manual\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>