### PR TITLE
fix(api): mobile aponta pra Fly.io por default + override via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
-EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-EXPO_PUBLIC_API_URL=http://localhost:8080
+# Optional overrides for app.config.js. All keys are OPTIONAL.
+# Without a .env, the app uses Fly.io API + Supabase prod (the right defaults
+# for any dev outside the LAN).
+#
+# Override only when running the API locally:
+#   EXPO_PUBLIC_API_URL=http://localhost:8080    # iOS simulator + web
+#   EXPO_PUBLIC_API_URL=http://10.0.2.2:8080     # Android emulator
+#   EXPO_PUBLIC_API_URL=http://192.168.x.x:8080  # Expo Go on physical device (LAN IP)
+
+EXPO_PUBLIC_API_URL=
+EXPO_PUBLIC_SUPABASE_URL=
+EXPO_PUBLIC_SUPABASE_ANON_KEY=

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,21 @@
+// Dynamic Expo config — wraps app.json so `extra` can be sourced from
+// EXPO_PUBLIC_* env vars at build time. This is how every environment override
+// (local API vs Fly prod, dev Supabase vs prod) flows into the runtime via
+// Constants.expoConfig.extra.
+//
+// Config dinamica do Expo: envolve o app.json para que `extra` seja sobrescrito
+// por variaveis EXPO_PUBLIC_* no build. Default aponta pra Fly de producao
+// porque eh o caminho que vai funcionar pra qualquer dev fora da rede LAN.
+
+const DEFAULT_API_URL = "https://forward-api-java.fly.dev";
+const DEFAULT_SUPABASE_URL = "https://ysewoopjgdpvnkfhffgy.supabase.co";
+
+module.exports = ({ config }) => ({
+  ...config,
+  extra: {
+    ...config.extra,
+    apiBaseUrl: process.env.EXPO_PUBLIC_API_URL ?? DEFAULT_API_URL,
+    supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL ?? DEFAULT_SUPABASE_URL,
+    supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? config.extra?.supabaseAnonKey,
+  },
+});

--- a/app.json
+++ b/app.json
@@ -35,8 +35,6 @@
       "typedRoutes": true
     },
     "extra": {
-      "apiBaseUrl": "http://localhost:18080",
-      "supabaseUrl": "https://ysewoopjgdpvnkfhffgy.supabase.co",
       "supabaseAnonKey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlzZXdvb3BqZ2Rwdm5rZmhmZmd5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYyMDg3OTUsImV4cCI6MjA5MTc4NDc5NX0.X1ZOlzHznQYN-fPlD_nWOzLL2ze9R7R7QCTD4e_jhJA"
     }
   }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,9 +3,11 @@
 
 import Constants from "expo-constants";
 
+// app.config.js writes apiBaseUrl from EXPO_PUBLIC_API_URL or falls back to Fly.
+// Esse fallback abaixo so cobre se alguem rodar sem app.config.js (build quebrada).
 const baseUrl =
   (Constants.expoConfig?.extra?.apiBaseUrl as string | undefined) ??
-  "http://localhost:18080";
+  "https://forward-api-java.fly.dev";
 
 export interface Problem {
   type: string;


### PR DESCRIPTION
## Summary

Mobile estava batendo em \`http://localhost:18080\` (porta tambem errada — Spring usa 8080) porque:
- \`app.json.extra.apiBaseUrl\` era string estatica sem caminho de override por env
- \`.env.example\` documentava \`EXPO_PUBLIC_API_URL\` mas nada lia
- Nao existia \`app.config.js\` pra ponte env vars -> \`Constants.expoConfig.extra\`

### Sintoma (web build)
\`\`\`
Access to fetch at 'http://localhost:18080/api/v1/leads?limit=200'
  from origin 'http://localhost:8081' has been blocked by CORS policy
GET http://localhost:18080/api/v1/leads?limit=200 net::ERR_FAILED
\`\`\`

### Fix
- **Novo \`app.config.js\`** envolve o \`app.json\` e escreve \`extra.apiBaseUrl\`, \`supabaseUrl\`, \`supabaseAnonKey\` a partir de \`process.env.EXPO_PUBLIC_*\` com Fly + Supabase prod como defaults. Comportamento padrao: funciona sem precisar de \`.env\`.
- Removidos \`apiBaseUrl\` e \`supabaseUrl\` do \`app.json\` (agora \`app.config.js\` e a fonte da verdade; \`supabaseAnonKey\` fica como fallback JSON por seguranca).
- Atualizado fallback no \`lib/api.ts\` pra Fly em vez de localhost (defense-in-depth se alguem rodar sem o app.config.js).
- Reescrito \`.env.example\` com exemplos de override por plataforma (iOS sim, Android emulator, Expo Go LAN).

### Verificacao
\`\`\`bash
npx expo config
# extra: { apiBaseUrl: 'https://forward-api-java.fly.dev', ... }
\`\`\`

### Companion
fwd-ford/forward-api-java#19 fixa o CORS preflight do lado API. Os dois precisam mergear pro web funcionar — sozinho cada um nao resolve. Expo Go no nativo passa a funcionar so com esse PR aqui (nativo nao tem CORS).

## Test plan

- [x] \`npx tsc --noEmit\` zero erros
- [x] \`npx expo config\` confirma apiBaseUrl resolvido pra Fly
- [ ] Pos-merge + API deployada: \`npm run web\` faz login + GET /api/v1/leads OK no browser
- [ ] Override local: criar \`.env\` com \`EXPO_PUBLIC_API_URL=http://localhost:8080\` e validar que mobile passa a bater no localhost

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>