### PR TITLE
polish(safearea): ScreenHeader owns top inset; tabs stop duplicating

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,7 +7,6 @@ import {
   Text,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
@@ -54,7 +53,6 @@ function computeHeroStats(leads: Lead[]): HeroStats {
 export default function HomeScreen() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
   const [leads, setLeads] = useState<Lead[]>([]);
@@ -120,7 +118,7 @@ export default function HomeScreen() {
       style={styles.container}
       data={initialLoading ? [] : topLeads}
       keyExtractor={(l) => l.id}
-      contentContainerStyle={[styles.list, { paddingTop: insets.top }]}
+      contentContainerStyle={styles.list}
       refreshControl={
         <RefreshControl
           refreshing={refreshing}

--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -8,7 +8,6 @@ import {
   Text,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
@@ -92,7 +91,6 @@ function applyFilters(leads: Lead[], filter: FilterKey, query: string): Lead[] {
 export default function LeadsScreen() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
   const [leads, setLeads] = useState<Lead[]>([]);
@@ -138,7 +136,7 @@ export default function LeadsScreen() {
   }
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={styles.container}>
       <ScreenHeader
         title={t("leads.title")}
         subtitle={

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -143,7 +143,7 @@ export default function ProfileScreen() {
   const avatarSource = profile?.full_name ?? "";
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={styles.container}>
       <ScrollView
         contentContainerStyle={[
           styles.scrollContent,

--- a/components/ui/ScreenHeader.tsx
+++ b/components/ui/ScreenHeader.tsx
@@ -6,6 +6,7 @@
 
 import { useMemo, type ReactNode } from "react";
 import { StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useTheme } from "@/context/ThemeContext";
 import { spacing, typography, type ThemeColors } from "@/lib/theme";
@@ -18,10 +19,11 @@ export interface ScreenHeaderProps {
 
 export function ScreenHeader({ title, subtitle, trailing }: ScreenHeaderProps) {
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: insets.top + spacing.lg }]}>
       <View style={styles.text}>
         <Text style={styles.title} numberOfLines={1}>
           {title}
@@ -45,7 +47,6 @@ function createStyles(c: ThemeColors) {
       justifyContent: "space-between",
       gap: spacing.md,
       paddingHorizontal: spacing.xl,
-      paddingTop: spacing.lg,
       paddingBottom: spacing.lg,
     },
     text: { flex: 1, gap: spacing.xs },


### PR DESCRIPTION
## Summary

Ultimo item do polish do [UX_QA_REPORT.md](docs/superpowers/UX_QA_REPORT.md):

- **P1-3 — SafeArea ScreenHeader**: Home, Leads e Profile cada uma aplicava \`paddingTop: insets.top\` no wrapper E o ScreenHeader adicionava \`paddingTop: spacing.lg\` em cima. Visualmente OK, mas era footgun pra qualquer tela nova esquecer o inset do wrapper.

\`ScreenHeader\` agora chama \`useSafeAreaInsets()\` internamente e renderiza \`paddingTop = insets.top + spacing.lg\`. As 3 telas dropam o inset do wrapper:
- Home: dropa o \`paddingTop: insets.top\` do \`contentContainerStyle\` da FlatList + remove \`useSafeAreaInsets\` import (nao usa mais nada).
- Leads: dropa o \`paddingTop\` do \`<View>\` wrapper + remove import.
- Profile: dropa o \`paddingTop\` do wrapper mas mantem o import (continua usando \`insets.bottom\` no scroll content).

## Test plan

- [x] \`npx tsc --noEmit\` zero erros
- [ ] Manual web/native: notch nao sobrepoe titulo nas 3 tabs
- [ ] Manual: criar tela nova com so \`<ScreenHeader>\` no topo — funciona sem precisar lembrar do inset

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>