### PR TITLE
feat(design): Glass Minimalist foundation [Fase 1]

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,25 @@
 import { Ionicons } from "@expo/vector-icons";
+import {
+  Fraunces_400Regular,
+  Fraunces_600SemiBold,
+  Fraunces_700Bold,
+} from "@expo-google-fonts/fraunces";
+import {
+  Inter_400Regular,
+  Inter_500Medium,
+  Inter_600SemiBold,
+  Inter_700Bold,
+} from "@expo-google-fonts/inter";
 import { useFonts } from "expo-font";
 import { Stack, useRouter, useSegments } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { StyleSheet, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useEffect, useState } from "react";
 
 import "@/i18n";
 import { IntroVideo } from "@/components/ui/IntroVideo";
+import { MeshBackground } from "@/components/ui/MeshBackground";
 import { LocaleProvider } from "@/context/LocaleContext";
 import { ThemeProvider, useTheme } from "@/context/ThemeContext";
 import { supabase } from "@/lib/supabase";
@@ -29,9 +42,20 @@ function RootStack() {
   const [introDone, setIntroDone] = useState(false);
   const [ready, setReady] = useState(false);
   const [session, setSession] = useState<Session | null>(null);
-  // Preload Ionicons so the first paint never shows empty glyph squares (FOIT).
-  // Pre-carrega Ionicons; sem isso, primeiro paint mostra quadrados vazios.
-  const [fontsLoaded] = useFonts(Ionicons.font);
+  // Preload Ionicons + Fraunces (display serif) + Inter (UI sans) so first
+  // paint never shows fallback fonts or empty glyph squares (FOIT).
+  // Pre-carrega Ionicons + Fraunces + Inter; sem isso, primeiro paint usa
+  // fonte de sistema e estraga a hierarquia tipografica.
+  const [fontsLoaded] = useFonts({
+    ...Ionicons.font,
+    Fraunces_400Regular,
+    Fraunces_600SemiBold,
+    Fraunces_700Bold,
+    Inter_400Regular,
+    Inter_500Medium,
+    Inter_600SemiBold,
+    Inter_700Bold,
+  });
 
   // Auth check runs in parallel with the intro — whichever finishes later unblocks the router.
   // Verificacao de sessao roda em paralelo com a intro — o mais lento destrava o router.
@@ -47,16 +71,22 @@ function RootStack() {
   useGuardedRedirect(ready && introDone && themeHydrated, session);
 
   return (
-    <>
+    <View style={styles.root}>
       <StatusBar style={mode === "dark" ? "light" : "dark"} />
+      {/* Mesh sits behind every route so glass surfaces have texture to blur. */}
+      {/* Mesh fica atras de tudo pra o glass ter algo pra borrar. */}
+      <MeshBackground />
       {!introDone ? (
         <IntroVideo onFinished={() => setIntroDone(true)} />
       ) : !ready || !themeHydrated || !fontsLoaded ? null : (
         <Stack
           screenOptions={{
-            headerStyle: { backgroundColor: colors.bg },
+            // contentStyle transparent so MeshBackground shows through every route.
+            // contentStyle transparente: deixa o MeshBackground aparecer atras.
+            headerStyle: { backgroundColor: "transparent" },
+            headerTransparent: true,
             headerTintColor: colors.text,
-            contentStyle: { backgroundColor: colors.bg },
+            contentStyle: { backgroundColor: "transparent" },
           }}
         >
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
@@ -64,9 +94,13 @@ function RootStack() {
           <Stack.Screen name="lead/[id]" options={{ title: "Lead" }} />
         </Stack>
       )}
-    </>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+});
 
 // useGuardedRedirect sends unauthenticated users to /login and authenticated
 // users away from /login to the tab root.

--- a/components/ui/GlassSurface.tsx
+++ b/components/ui/GlassSurface.tsx
@@ -1,0 +1,84 @@
+// Glass surface — semi-transparent + blur. Abstraction over platform diffs:
+//   iOS / web   -> expo-blur BlurView (web: backdrop-filter via the lib)
+//   Android     -> rgba fill only (real blur is jank in long lists on Android)
+//
+// Variants control blur intensity + opacity. Use `regular` by default,
+// `thin` for nested surfaces, `thick` for sheets and modals.
+//
+// Superficie glass: blur real no iOS/web; fill rgba no Android (perf).
+
+import { useMemo, type ReactNode } from "react";
+import { Platform, StyleSheet, View, type ViewStyle } from "react-native";
+import { BlurView } from "expo-blur";
+
+import { useTheme } from "@/context/ThemeContext";
+
+export type GlassVariant = "thin" | "regular" | "thick";
+
+export interface GlassSurfaceProps {
+  variant?: GlassVariant;
+  radius?: number;
+  border?: boolean;
+  style?: ViewStyle | ViewStyle[];
+  children?: ReactNode;
+}
+
+const INTENSITY: Record<GlassVariant, number> = {
+  thin: 30,
+  regular: 60,
+  thick: 90,
+};
+
+// Android falls back to fill-only — these alphas keep parity with the visual
+// weight of the blur intensities above.
+const ANDROID_ALPHA: Record<GlassVariant, number> = {
+  thin: 0.45,
+  regular: 0.6,
+  thick: 0.78,
+};
+
+export function GlassSurface({
+  variant = "regular",
+  radius = 20,
+  border = true,
+  style,
+  children,
+}: GlassSurfaceProps) {
+  const { colors, mode } = useTheme();
+
+  const containerStyle = useMemo<ViewStyle>(
+    () => ({
+      borderRadius: radius,
+      overflow: "hidden",
+      borderWidth: border ? StyleSheet.hairlineWidth : 0,
+      borderColor: colors.glassBorder,
+      backgroundColor: Platform.OS === "android" ? androidFill(mode, variant) : "transparent",
+    }),
+    [radius, border, colors.glassBorder, mode, variant],
+  );
+
+  if (Platform.OS === "android") {
+    return <View style={[containerStyle, style]}>{children}</View>;
+  }
+
+  // BlurView for iOS + web (expo-blur uses backdrop-filter on web).
+  // tint='default' adapts to theme; we pass dark/light explicitly so the
+  // glass reads correctly even when device theme disagrees with app theme.
+  return (
+    <View style={[containerStyle, style]}>
+      <BlurView
+        intensity={INTENSITY[variant]}
+        tint={mode === "dark" ? "dark" : "light"}
+        style={StyleSheet.absoluteFill}
+      />
+      {children}
+    </View>
+  );
+}
+
+function androidFill(mode: "light" | "dark", variant: GlassVariant): string {
+  const alpha = ANDROID_ALPHA[variant];
+  return mode === "dark"
+    ? `rgba(40, 40, 40, ${alpha})`
+    : `rgba(255, 255, 255, ${alpha})`;
+}

--- a/components/ui/MeshBackground.tsx
+++ b/components/ui/MeshBackground.tsx
@@ -1,0 +1,61 @@
+// Mesh gradient background — fixed at the root, sits behind every screen so
+// the glass surfaces have texture to blur into. Three radial-style layers
+// (top-left, top-right, bottom) over a flat base color. Static, no animation.
+//
+// Bg mesh fixo no root: 3 camadas de gradiente sobre cor base. Sem animacao.
+
+import { useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+import { useTheme } from "@/context/ThemeContext";
+
+type MeshConfig = {
+  base: string;
+  topLeft: [string, string];
+  topRight: [string, string];
+  bottom: [string, string];
+};
+
+const MESH: Record<"light" | "dark", MeshConfig> = {
+  dark: {
+    base: "#161616",
+    topLeft: ["rgba(40, 40, 55, 0.35)", "rgba(40, 40, 55, 0)"],
+    topRight: ["rgba(60, 40, 40, 0.20)", "rgba(60, 40, 40, 0)"],
+    bottom: ["rgba(30, 30, 35, 0)", "rgba(22, 22, 22, 0.45)"],
+  },
+  light: {
+    base: "#F0F0F2",
+    topLeft: ["rgba(220, 220, 235, 0.50)", "rgba(220, 220, 235, 0)"],
+    topRight: ["rgba(245, 240, 235, 0.35)", "rgba(245, 240, 235, 0)"],
+    bottom: ["rgba(240, 240, 242, 0)", "rgba(240, 240, 242, 0.40)"],
+  },
+};
+
+export function MeshBackground() {
+  const { mode } = useTheme();
+  const cfg = useMemo(() => MESH[mode], [mode]);
+
+  return (
+    <View style={[StyleSheet.absoluteFill, { backgroundColor: cfg.base }]} pointerEvents="none">
+      <LinearGradient
+        colors={cfg.topLeft}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0.7, y: 0.6 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={cfg.topRight}
+        start={{ x: 1, y: 0 }}
+        end={{ x: 0.3, y: 0.6 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={cfg.bottom}
+        start={{ x: 0.5, y: 0.4 }}
+        end={{ x: 0.5, y: 1 }}
+        style={StyleSheet.absoluteFill}
+      />
+    </View>
+  );
+}

--- a/docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
+++ b/docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
@@ -1,0 +1,212 @@
+# Glass Minimalist — Design System Spec
+
+**Data:** 2026-05-23
+**Autor:** Jota + Claude Opus 4.7
+**Status:** approved, em implementacao
+
+## Motivacao
+
+O design anterior (Ford Blue agressivo + cards solidos + tipografia sans-only) nao alcancou o look minimalista premium que o produto pede. Refs visuais aprovados:
+
+- **Base estetica** (Mailchimp / Mobbin): label-caps minusculo + titulo serif gigante, hierarquia hiper-clara, cards com bordas leves, muito espaco em branco.
+- **Camada glass** (TIDE app): superficies semi-transparentes com blur ("frosted glass"), bg dark sutil quase preto, icones outline finos, CTAs brancos pill.
+
+Objetivo: combinar **Mailchimp em hierarquia tipografica** + **TIDE em superficies glass** sob a marca Ford (reduzida ao logo).
+
+## Decisoes fechadas
+
+| | Decisao |
+|---|---|
+| Modos | Light + dark com paridade total. Dark e a estrela. |
+| Ford Blue | So no wordmark/logo. UI = grayscale + branco. CTAs brancos (pill) em dark, pretos (pill) em light. |
+| Fontes | Fraunces (display serif variable) + Inter (sans body) via expo-google-fonts |
+| Glass | Agressivo (TIDE-style): cards, inputs, hero, tab bar, modais. Tudo |
+| BG | Mesh gradient abstrato estatico (sem foto, sem animacao). 3 radial gradients sobrepostos |
+
+## Tokens de cor
+
+### Dark
+```
+bg               #1E1E1E    (RGB 30,30,30 — pedido explicito)
+bgDeep           #161616    (sutilmente mais escuro pra mesh)
+bgElevated       #252525    (cards solidos elevados, fallback sem glass)
+glassBase        rgba(40,40,40,0.55)    + backdrop-blur 24px
+glassBorder      rgba(255,255,255,0.08)
+textPrimary      #F5F5F5    (nao puro branco)
+textMuted        #9CA3AF
+textSubtle       #6B7280
+separator        rgba(255,255,255,0.06)
+```
+
+### Light
+```
+bg               #FAFAFA    (off-white)
+bgDeep           #F0F0F2
+bgElevated       #FFFFFF
+glassBase        rgba(255,255,255,0.65)    + backdrop-blur 24px
+glassBorder      rgba(0,0,0,0.06)
+textPrimary      #1A1A1A
+textMuted        #6B7280
+textSubtle       #9CA3AF
+separator        rgba(0,0,0,0.05)
+```
+
+### Brand + semantic (compartilhado)
+```
+fordBlue         #003478    APENAS wordmark/logo. NUNCA UI.
+ctaDark          #FFFFFF    pill branco em dark
+ctaLight         #1A1A1A    pill preto em light
+success          #10B981
+warning          #F59E0B
+error            #EF4444
+critical         #FF453A    (Apple red)
+```
+
+## Tipografia
+
+```
+Display:  Fraunces (variable 100-900, soft, opt-sized)
+Body:     Inter (variable 100-900)
+Mono:     SF Mono / Cascadia / Consolas (system stack, sem bundle)
+
+Escala:
+  h-display    40px  Fraunces 700  letter-spacing -1.2   titulos de tela
+  h-section    28px  Fraunces 600  letter-spacing -0.8   section headers
+  h3           18px  Inter 600                            subsections
+  body-lg      17px  Inter 400                            paragraphs
+  body         15px  Inter 400                            default
+  caption      13px  Inter 400
+  label-caps   11px  Inter 600     letter-spacing +1.0    Mailchimp uppercase
+  mono         15px  Mono 500
+```
+
+Bundle via `useFonts` em `_layout.tsx` (mesmo pattern de Ionicons).
+
+## Sistema de glass
+
+Componente `<GlassSurface>` abstrai por plataforma:
+
+```
+iOS native:     expo-blur BlurView intensity=80 + tint='regular'|'dark'
+Android native: rgba fill semi-transparent + borda glassBorder
+                (Android blur real tem perf ruim em listas)
+Web:            backdrop-filter: blur(24px) + bg glassBase + borda
+```
+
+Variantes:
+- `thin` — blur 12px, mais transparente, pra surfaces aninhadas
+- `regular` — blur 24px, padrao
+- `thick` — blur 40px, modais e sheets
+
+API:
+```tsx
+<GlassSurface variant="regular" radius={20}>
+  {children}
+</GlassSurface>
+```
+
+## Mesh gradient background
+
+Componente `<MeshBackground>` fixo no root, atras de tudo. Implementacao: `expo-linear-gradient` em 3 layers absoluteFill.
+
+```
+Dark:
+  base:        #161616
+  layer 1:     top-left,   rgba(40,40,55,0.35)  -> transparent
+  layer 2:     top-right,  rgba(60,40,40,0.20)  -> transparent
+  layer 3:     bottom,     rgba(30,30,35,0.45)  -> bgDeep
+
+Light:
+  base:        #F0F0F2
+  layer 1:     top-left,   rgba(220,220,235,0.50) -> transparent
+  layer 2:     top-right,  rgba(245,240,235,0.35) -> transparent
+  layer 3:     bottom,     rgba(240,240,242,0.40) -> bgDeep
+```
+
+## Padroes por tela
+
+### Login
+- bg mesh + wordmark **FORD** Fraunces 56px branco
+- tagline Inter 15px muted abaixo
+- inputs underline-only (sem borda completa, sem card glass) — minimalista
+- CTA branco pill bottom + Esqueci senha em ghost
+
+### Home
+```
+[mesh bg]
+  HOJE                           label-caps 11
+  Bom dia, Jota                  Fraunces 40
+  ┌─────────────── glass ───────────────┐
+  │  LEADS ATIVOS    PIPELINE           │
+  │       12         R$ 1.2M            │
+  └─────────────────────────────────────┘
+  Leads recentes                 Fraunces 28
+  [glass card lead 1]
+  [glass card lead 2]
+  ...
+  [tab bar glass thick]
+```
+
+### Leads
+- Mesmo header pattern (label-caps + Fraunces titulo)
+- Search bar glass pill
+- Filter chips glass (active = solid white com text dark)
+- Lista de glass cards
+
+### Profile
+- Avatar 80px circular + nome Fraunces 28px + email Inter muted
+- Sections com label-caps + glass rows separadas por separator
+- Sem card wrapper, rows ficam direto sobre o mesh com glass
+
+### Lead detail
+- Header stack minimo
+- Label-caps `LEAD` + VIN mono grande
+- Status pill colored (mantem palette de status)
+- Glass sections de info
+- Footer fixed glass thick com 3 CTAs
+
+### Tab bar
+- Glass thick com 4 icones outline finos + 1 central destacado
+- Sem labels (ou labels so no active, estilo iOS)
+
+## Ordem de implementacao
+
+### Fase 1 — Foundation (1 PR)
+- `theme.ts`: novas paletas dark/light com tokens acima
+- `_layout.tsx`: useFonts(Fraunces + Inter)
+- `components/ui/MeshBackground.tsx`: novo componente fixo no root
+- `components/ui/GlassSurface.tsx`: novo componente com abstracao de blur
+
+### Fase 2 — Telas, 1 PR por tela, sem componentizar
+Estilos copiados inline em cada tela. Componentizacao vem depois.
+
+1. Login
+2. Home
+3. Leads
+4. Profile
+5. Lead detail
+6. Tab bar (glass)
+
+### Fase 3 — Componentizacao
+Depois que todas as telas estiverem certas:
+- `<ScreenTitle>` — label-caps + Fraunces titulo + opt subtitle
+- `<GlassCard>` — wrapper com variantes thin/regular/thick
+- `<PillButton>` — variantes solid/glass/ghost com pill radius
+- Refatorar telas pra usar novos componentes
+
+## Migracao das telas existentes
+
+Telas atuais ja tem:
+- ScreenHeader (deprecate por ScreenTitle na fase 3)
+- Card (deprecate por GlassCard na fase 3)
+- Button (manter, ganha variante `pill`)
+- ErrorBanner, EmptyState, Toast — mantem, ganham GlassSurface por dentro
+
+i18n keys nao mudam (so visuals).
+
+## Riscos e mitigacoes
+
+- **Performance do blur no Android**: usar fallback rgba semi-transparent. Testar em emulador antes de mergear cada PR.
+- **Bundle size das fontes**: Fraunces + Inter variable ~400KB combinado. Aceitavel pra UX premium.
+- **Web fallback do blur**: `backdrop-filter` tem suporte ~95% (caniuse). Browsers antigos veem rgba sem blur — degradacao OK.
+- **Mesh gradient em listas longas**: fixed atras de tudo, nao re-renderiza. Performance neutra.

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,28 +1,39 @@
-// Design tokens for the ForwardService mobile app.
-// Two palettes (light + dark) keyed by semantic tokens. Screens consume via
-// useTheme() — never import `palette` directly.
-// Tokens de design: paletas light/dark, espacamento, tipografia, elevacao.
+// Design tokens for the ForwardService mobile app — Glass Minimalist redesign.
+// Light + dark palettes keyed by semantic tokens. Screens consume via useTheme().
+// Spec: docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
+//
+// Tokens de design: paletas light/dark, glass, tipografia Fraunces+Inter.
 
 import { Platform } from "react-native";
 
 export type ThemeMode = "light" | "dark";
 
 export type ThemeColors = {
+  // Base surfaces
   bg: string;
+  bgDeep: string;
   bgElevated: string;
   surface: string;
   surfaceElevated: string;
   surfaceHover: string;
+  // Glass (new): semi-transparent, paired with backdrop-blur at the consumer.
+  glassBase: string;
+  glassBorder: string;
+  // Borders + separators
   border: string;
   borderStrong: string;
   separator: string;
+  // Text
   text: string;
   textMuted: string;
   textSubtle: string;
+  // Primary CTA — white pill in dark, dark pill in light (TIDE-style).
+  // Brand fordBlue is exported separately and used ONLY in the wordmark.
   primary: string;
   primaryDeep: string;
   primaryText: string;
   primarySoft: string;
+  // Status / semantic
   success: string;
   successSoft: string;
   warning: string;
@@ -30,36 +41,38 @@ export type ThemeColors = {
   error: string;
   errorSoft: string;
   critical: string;
+  // Misc
   overlay: string;
   tabBar: string;
   inputBg: string;
 };
 
-// Ford Blue is the brand primary. Light uses the classic deep blue; dark uses
-// a lighter, more saturated variant for legibility on dark backgrounds.
-// Azul Ford classico (#003478) no light; variante mais clara no dark.
+// Ford Blue is the brand mark. Used ONLY on the FORD wordmark + logo glyph.
+// Never on CTAs, switches, tabs, or any interactive surface.
+// Azul Ford apenas no wordmark/logo. Nunca em UI interativa.
 export const FORD_BLUE = "#003478";
 export const FORD_BLUE_DEEP = "#002356";
-export const FORD_BLUE_DARK_MODE = "#5B8DEF";
-export const FORD_BLUE_DARK_MODE_DEEP = "#3D6FCC";
 
 export const palette: Record<ThemeMode, ThemeColors> = {
   light: {
-    bg: "#F7F8FA",
+    bg: "#FAFAFA",
+    bgDeep: "#F0F0F2",
     bgElevated: "#FFFFFF",
     surface: "#FFFFFF",
     surfaceElevated: "#FFFFFF",
-    surfaceHover: "#F1F3F7",
-    border: "rgba(11, 18, 32, 0.08)",
-    borderStrong: "rgba(11, 18, 32, 0.14)",
-    separator: "rgba(11, 18, 32, 0.05)",
-    text: "#0B1220",
-    textMuted: "#56627A",
-    textSubtle: "#8E97AC",
-    primary: FORD_BLUE,
-    primaryDeep: FORD_BLUE_DEEP,
-    primaryText: "#FFFFFF",
-    primarySoft: "rgba(0, 52, 120, 0.10)",
+    surfaceHover: "#F4F4F6",
+    glassBase: "rgba(255, 255, 255, 0.65)",
+    glassBorder: "rgba(0, 0, 0, 0.06)",
+    border: "rgba(0, 0, 0, 0.08)",
+    borderStrong: "rgba(0, 0, 0, 0.14)",
+    separator: "rgba(0, 0, 0, 0.05)",
+    text: "#1A1A1A",
+    textMuted: "#6B7280",
+    textSubtle: "#9CA3AF",
+    primary: "#1A1A1A",
+    primaryDeep: "#000000",
+    primaryText: "#FAFAFA",
+    primarySoft: "rgba(26, 26, 26, 0.06)",
     success: "#0F8A5F",
     successSoft: "rgba(15, 138, 95, 0.10)",
     warning: "#B5670A",
@@ -68,48 +81,56 @@ export const palette: Record<ThemeMode, ThemeColors> = {
     errorSoft: "rgba(199, 54, 58, 0.10)",
     critical: "#A11A20",
     overlay: "rgba(11, 18, 32, 0.40)",
-    tabBar: "rgba(255, 255, 255, 0.92)",
-    inputBg: "#FFFFFF",
+    tabBar: "rgba(255, 255, 255, 0.78)",
+    inputBg: "rgba(255, 255, 255, 0.60)",
   },
   dark: {
-    bg: "#0B1220",
-    bgElevated: "#101A2E",
-    surface: "#121A2B",
-    surfaceElevated: "#1A2336",
-    surfaceHover: "#1F2A40",
+    bg: "#1E1E1E",
+    bgDeep: "#161616",
+    bgElevated: "#252525",
+    surface: "#252525",
+    surfaceElevated: "#2A2A2A",
+    surfaceHover: "#303030",
+    glassBase: "rgba(40, 40, 40, 0.55)",
+    glassBorder: "rgba(255, 255, 255, 0.08)",
     border: "rgba(255, 255, 255, 0.07)",
     borderStrong: "rgba(255, 255, 255, 0.12)",
-    separator: "rgba(255, 255, 255, 0.05)",
-    text: "#E6EDF7",
-    textMuted: "#93A1B8",
-    textSubtle: "#6C7A95",
-    primary: FORD_BLUE_DARK_MODE,
-    primaryDeep: FORD_BLUE_DARK_MODE_DEEP,
-    primaryText: "#FFFFFF",
-    primarySoft: "rgba(91, 141, 239, 0.16)",
+    separator: "rgba(255, 255, 255, 0.06)",
+    text: "#F5F5F5",
+    textMuted: "#9CA3AF",
+    textSubtle: "#6B7280",
+    primary: "#FAFAFA",
+    primaryDeep: "#E5E5E5",
+    primaryText: "#1A1A1A",
+    primarySoft: "rgba(250, 250, 250, 0.10)",
     success: "#2DB67B",
     successSoft: "rgba(45, 182, 123, 0.16)",
     warning: "#E3A93C",
     warningSoft: "rgba(227, 169, 60, 0.16)",
     error: "#E5484D",
     errorSoft: "rgba(229, 72, 77, 0.16)",
-    critical: "#FF5463",
+    critical: "#FF453A",
     overlay: "rgba(0, 0, 0, 0.6)",
-    tabBar: "rgba(11, 18, 32, 0.85)",
-    inputBg: "#121A2B",
+    tabBar: "rgba(30, 30, 30, 0.72)",
+    inputBg: "rgba(40, 40, 40, 0.55)",
   },
 };
 
+// Font families — Fraunces (display serif) + Inter (sans body) loaded via
+// expo-google-fonts in _layout.tsx. Names below match the package exports.
+// Mono uses system stack (no bundle), with proper Windows fallback.
+// Fontes: Fraunces + Inter via @expo-google-fonts; mono fica em system stack.
 export const fontFamily = {
-  regular: "System",
-  medium: "System",
-  semibold: "System",
-  bold: "System",
-  extrabold: "System",
-  // Web fallback list ordered for legibility on Windows/macOS/Linux: native
-  // monos first, then bundled-with-Windows Cascadia/Consolas. Bare "ui-monospace"
-  // collapsed to a chunky serif on Windows.
-  // Stack ordenada por sistema: Windows nao tem SF Mono, entao precisa de Cascadia/Consolas.
+  // Display serif (Fraunces) — for h-display + h-section.
+  displayRegular: "Fraunces_400Regular",
+  displaySemibold: "Fraunces_600SemiBold",
+  displayBold: "Fraunces_700Bold",
+  // Sans body (Inter) — for body, captions, labels, mono fallback.
+  regular: "Inter_400Regular",
+  medium: "Inter_500Medium",
+  semibold: "Inter_600SemiBold",
+  bold: "Inter_700Bold",
+  // Mono stack (system).
   mono: Platform.select({
     ios: "Menlo",
     android: "monospace",
@@ -118,9 +139,9 @@ export const fontFamily = {
   }) as string,
 } as const;
 
-// Weight tokens — paired with fontFamily.System on RN to get bold variants
-// without bundling custom fonts. When we ship Manrope/Inter later, swap families.
-// Pesos: enquanto nao ha fonte custom, usa system + fontWeight numerico.
+// Numeric weights kept for any caller that still spreads typography helpers.
+// React Native maps these to the loaded font weights automatically when the
+// fontFamily explicitly carries the weight (e.g. Inter_600SemiBold).
 export const fontWeight = {
   regular: "400",
   medium: "500",
@@ -139,8 +160,8 @@ export const fontSize = {
   "2xl": 22,
   "3xl": 28,
   "4xl": 32,
-  "5xl": 48,
-  "6xl": 72,
+  "5xl": 40,
+  "6xl": 56,
 } as const;
 
 export const spacing = {
@@ -176,8 +197,9 @@ export const letterSpacing = {
   ultra: 6,
 } as const;
 
-// Elevation pra light: sombras reais (iOS shadow* + Android elevation).
-// Hierarquia visual depende da luz vinda de cima.
+// Elevation light: real shadows. Elevation dark: subtle top-highlight only
+// (shadows on dark turn into smudges; Vercel/Cursor pattern).
+// Glass surfaces dont use either — they get a thin border via glassBorder.
 export const elevationLight = {
   none: {
     shadowColor: "transparent",
@@ -208,7 +230,7 @@ export const elevationLight = {
     elevation: 4,
   },
   primary: {
-    shadowColor: FORD_BLUE,
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.16,
     shadowRadius: 12,
@@ -216,8 +238,6 @@ export const elevationLight = {
   },
 } as const;
 
-// Elevation pra dark: zero sombra. Hierarquia via top-highlight (borda superior
-// clarinha). Estetica Vercel/Cursor — sombras em fundo escuro viram manchas.
 export const elevationDark = {
   none: {},
   sm: { borderTopColor: "rgba(255,255,255,0.04)", borderTopWidth: 1 },
@@ -226,9 +246,6 @@ export const elevationDark = {
   primary: { borderTopColor: "rgba(255,255,255,0.10)", borderTopWidth: 1 },
 } as const;
 
-// Semantic elevation aliases — usar nas telas em vez de sm/md/lg/primary direto.
-// Card = elemento normal. Sheet = modal/bottom-sheet. Popover = floating action.
-// Aliases semanticos: card / sheet / popover.
 export const elevationAliasLight = {
   card: elevationLight.sm,
   sheet: elevationLight.lg,
@@ -243,27 +260,74 @@ export const elevationAliasDark = {
 
 export type Elevation = typeof elevationLight | typeof elevationDark;
 
-// Typography helpers que combinam size + weight + lineHeight em um objeto
-// pronto pra spread. Substitui o `typography.h1` antigo, agora tema-aware
-// no consumer (cor vem de useTheme()).
-// Helpers de tipografia: spread direto no style.
+// Typography helpers — Fraunces for display, Inter for everything else.
+// Spread directly into a Text style. Color comes from useTheme() at the
+// consumer (these helpers are color-agnostic).
+//
+// Display = page titles, section titles. Heavy serif presence.
+// Body / caption / label = all Inter for UI consistency.
+// Tipografia: Fraunces no display, Inter no resto. Cor vem do consumer.
 export const typography = {
-  h1: {
+  // Display — Fraunces serif.
+  hDisplay: {
+    fontFamily: fontFamily.displayBold,
+    fontSize: fontSize["5xl"],
+    lineHeight: 44,
+    letterSpacing: -1.2,
+  },
+  hSection: {
+    fontFamily: fontFamily.displaySemibold,
     fontSize: fontSize["3xl"],
-    fontWeight: fontWeight.extrabold,
-    lineHeight: 34,
-    letterSpacing: -0.4,
+    lineHeight: 32,
+    letterSpacing: -0.8,
+  },
+  // Legacy aliases (h1/h2) so screens not yet migrated keep working.
+  // Aliases legados pra telas ainda nao migradas.
+  h1: {
+    fontFamily: fontFamily.displayBold,
+    fontSize: fontSize["5xl"],
+    lineHeight: 44,
+    letterSpacing: -1.2,
   },
   h2: {
-    fontSize: fontSize["2xl"],
-    fontWeight: fontWeight.bold,
-    lineHeight: 28,
-    letterSpacing: -0.3,
+    fontFamily: fontFamily.displaySemibold,
+    fontSize: fontSize["3xl"],
+    lineHeight: 32,
+    letterSpacing: -0.8,
   },
-  h3: { fontSize: fontSize.xl, fontWeight: fontWeight.semibold, lineHeight: 24 },
-  body: { fontSize: fontSize.lg, fontWeight: fontWeight.regular, lineHeight: 22 },
-  caption: { fontSize: fontSize.md, fontWeight: fontWeight.regular, lineHeight: 18 },
-  label: { fontSize: fontSize.sm, fontWeight: fontWeight.semibold, letterSpacing: 0.5 },
+  // Body — Inter sans.
+  h3: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.xl,
+    lineHeight: 24,
+  },
+  bodyLg: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.lg + 1,
+    lineHeight: 24,
+  },
+  body: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.lg,
+    lineHeight: 22,
+  },
+  caption: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.md,
+    lineHeight: 18,
+  },
+  label: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.sm,
+    letterSpacing: 0.5,
+  },
+  // Mailchimp-style uppercase tag.
+  labelCaps: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.sm,
+    letterSpacing: 1.4,
+    textTransform: "uppercase" as const,
+  },
   mono: {
     fontFamily: fontFamily.mono,
     fontSize: fontSize.lg,
@@ -334,7 +398,6 @@ export const leadStatusPalette: Record<LeadStatusKey, StatusPaletteEntry> = {
   },
 };
 
-// Priority palette: mapeia api Lead.priority. Critical chama atencao maxima.
 export type LeadPriorityKey = "low" | "medium" | "high" | "critical";
 
 export const leadPriorityPalette: Record<LeadPriorityKey, StatusPaletteEntry> = {
@@ -352,19 +415,18 @@ export const leadPriorityPalette: Record<LeadPriorityKey, StatusPaletteEntry> = 
   },
   high: {
     labelKey: "priority.high",
-    color: FORD_BLUE_DARK_MODE,
+    color: "#5B8DEF",
     bg: "rgba(91, 141, 239, 0.16)",
     border: "rgba(91, 141, 239, 0.45)",
   },
   critical: {
     labelKey: "priority.critical",
-    color: "#FF5463",
-    bg: "rgba(255, 84, 99, 0.16)",
-    border: "rgba(255, 84, 99, 0.50)",
+    color: "#FF453A",
+    bg: "rgba(255, 69, 58, 0.16)",
+    border: "rgba(255, 69, 58, 0.50)",
   },
 };
 
-// Churn segment palette: mapeia segment do ChurnScore.
 export type ChurnSegmentKey = "fiel" | "abandono" | "esquecido" | "economico";
 
 export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = {
@@ -376,9 +438,9 @@ export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = 
   },
   abandono: {
     labelKey: "segment.abandono",
-    color: "#FF5463",
-    bg: "rgba(255, 84, 99, 0.14)",
-    border: "rgba(255, 84, 99, 0.40)",
+    color: "#FF453A",
+    bg: "rgba(255, 69, 58, 0.14)",
+    border: "rgba(255, 69, 58, 0.40)",
   },
   esquecido: {
     labelKey: "segment.esquecido",
@@ -394,9 +456,9 @@ export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = 
   },
 };
 
-// Tokens legados — mantidos para callers ainda nao migrados. Vao sumir
-// conforme as telas adotam useTheme(). NAO usar em codigo novo.
-// Legacy tokens: nao usar em codigo novo. Migrar para useTheme().
+// Legacy color export — kept so any code path still importing from this module
+// instead of useTheme() does not break. Migrate consumers to useTheme().
+// Tokens legados: nao usar em codigo novo. Migrar para useTheme().
 export const colors = palette.dark;
 export type ColorToken = keyof ThemeColors;
 export type SpacingToken = keyof typeof spacing;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,18 @@
       "name": "forward-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@expo-google-fonts/fraunces": "^0.4.1",
+        "@expo-google-fonts/inter": "^0.4.2",
         "@expo/metro-runtime": "~55.0.9",
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@supabase/supabase-js": "^2.45.0",
         "expo": "^55.0.15",
+        "expo-blur": "~55.0.14",
         "expo-constants": "~55.0.14",
         "expo-haptics": "~55.0.14",
         "expo-image-picker": "~55.0.20",
+        "expo-linear-gradient": "~55.0.14",
         "expo-linking": "~55.0.13",
         "expo-router": "~55.0.12",
         "expo-secure-store": "~55.0.13",
@@ -1424,6 +1428,18 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/@expo-google-fonts/fraunces": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/fraunces/-/fraunces-0.4.1.tgz",
+      "integrity": "sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/inter": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.4.2.tgz",
+      "integrity": "sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/material-symbols": {
       "version": "0.4.31",
@@ -4458,6 +4474,17 @@
         }
       }
     },
+    "node_modules/expo-blur": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-55.0.14.tgz",
+      "integrity": "sha512-NKyCKFWTNpX4CZSsiE1sgkqk/yvR1K0UTukuIbxVKoobB+yALLg1CFav0NqfdQqjhtoj5oEzP0Brlq92Z08Zfg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "55.0.14",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.14.tgz",
@@ -4545,6 +4572,17 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-55.0.14.tgz",
+      "integrity": "sha512-n01A9P0ZebRo8Rm4QHYEjMR8z4Y6MBc8uVnT8NB9cOJislvEmz2o2WQJoK6RD7FjoeFEW8KkRtggK7fQ3h7KIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@expo-google-fonts/fraunces": "^0.4.1",
+    "@expo-google-fonts/inter": "^0.4.2",
     "@expo/metro-runtime": "~55.0.9",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@supabase/supabase-js": "^2.45.0",
     "expo": "^55.0.15",
+    "expo-blur": "~55.0.14",
     "expo-constants": "~55.0.14",
     "expo-haptics": "~55.0.14",
     "expo-image-picker": "~55.0.20",
+    "expo-linear-gradient": "~55.0.14",
     "expo-linking": "~55.0.13",
     "expo-router": "~55.0.12",
     "expo-secure-store": "~55.0.13",


### PR DESCRIPTION
## Summary

Fase 1 do redesign Glass Minimalist. Spec em [docs/superpowers/specs/2026-05-23-glass-minimalist-design.md](docs/superpowers/specs/2026-05-23-glass-minimalist-design.md).

### Decisoes (aprovadas em brainstorm)
- Light + dark com paridade total
- Ford Blue **apenas** no wordmark/logo (UI = grayscale + branco/preto)
- Fraunces (display serif) + Inter (sans body) via @expo-google-fonts
- Glass agressivo (TIDE-style) em cards, tab bar, modais
- BG: mesh gradient abstrato estatico

### O que esta PR muda

**\`lib/theme.ts\` — paletas + tipografia novas:**
- Dark anchor em \`#1E1E1E\` (30,30,30 pedido), \`bgDeep #161616\` pro mesh, \`glassBase rgba(40,40,40,0.55)\`
- Light anchor em \`#FAFAFA\`, \`glassBase rgba(255,255,255,0.65)\`
- \`primary\` (CTA) virou branco em dark, preto em light — Ford Blue saiu da UI
- Tipografia: \`hDisplay\` 40px Fraunces, \`hSection\` 28px Fraunces, body/caption/label em Inter, novo \`labelCaps\` pra tags estilo Mailchimp

**\`components/ui/MeshBackground.tsx\` (novo):**
- 3 \`LinearGradient\` sobrepostos (top-left, top-right, bottom) sobre cor base
- \`absoluteFill\` no root, atras de tudo
- Sem animacao

**\`components/ui/GlassSurface.tsx\` (novo):**
- \`BlurView\` no iOS/web (backdrop-filter no web via expo-blur)
- Android cai em \`rgba\` fill (blur real eh jank em listas Android)
- Variantes \`thin\` / \`regular\` / \`thick\` (intensity 30/60/90)

**\`app/_layout.tsx\`:**
- \`useFonts\` agora carrega Fraunces 400/600/700 + Inter 400/500/600/700 + Ionicons
- Monta \`<MeshBackground />\` no root
- Stack \`screenOptions\` virou transparente pro mesh atravessar todas as rotas

**Deps adicionadas:** \`expo-blur\`, \`expo-linear-gradient\`, \`@expo-google-fonts/fraunces\`, \`@expo-google-fonts/inter\`

### O que NAO mexe
Telas atuais continuam renderizando o layout antigo, agora em cima do mesh + fontes novas. Fase 2 migra tela-a-tela (1 PR por tela), Fase 3 componentiza.

## Test plan

- [x] \`npx tsc --noEmit\` zero erros
- [ ] Manual: abrir o app — deve ver mesh gradient sutil atras do conteudo existente
- [ ] Manual: trocar tema light/dark — mesh muda de paleta
- [ ] Manual: textos legados (h1, h2, body) agora renderizam em Fraunces/Inter (Fraunces aparece nos titulos h1)
- [ ] Manual: confirmar sem flash de fonte fallback (FOIT) no cold start

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>