### PR TITLE
feat(design): Home + LeadCard Glass [Fase 2, 2/6]

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,3 +1,13 @@
+// Home — Glass Minimalist redesign (Fase 2, screen 2/6).
+// Layout:
+//   label-caps "HOJE" -> Fraunces 40 greeting
+//   GlassSurface hero with 2 KPI columns (active leads + pipeline)
+//   "Leads recentes" Fraunces 28 section header
+//   Lista de LeadCards (LeadCard ja foi migrado pra GlassSurface thin)
+//
+// Header inline per the screen-by-screen workflow; ScreenTitle vira component
+// na Fase 3 quando todas as telas tiverem o mesmo padrao.
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FlatList,
@@ -12,18 +22,16 @@ import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
 import { LeadCardSkeleton } from "@/components/domain/LeadCardSkeleton";
-import { Button } from "@/components/ui/Button";
-import { Card } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
-import { ScreenHeader } from "@/components/ui/ScreenHeader";
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { useTheme } from "@/context/ThemeContext";
 import { ACTIVE_LEAD_STATUSES, api, ApiError, type Lead } from "@/lib/api";
 import { formatBRL } from "@/lib/format";
 import { fetchMyProfile } from "@/lib/profile";
 import { getAccessToken } from "@/lib/session";
 import { supabase } from "@/lib/supabase";
-import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { fontFamily, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
 type HeroStats = {
   activeLeads: number;
@@ -32,9 +40,8 @@ type HeroStats = {
 
 const TOP_VISIBLE = 5;
 // Hero stats sao calculados client-side a partir do array retornado por listLeads.
-// Sprint 1 nao tem endpoint dedicado de agregacao (/leads/stats), entao puxamos um
-// teto bem acima da expectativa real por vendedor (~50 leads ativos). Quando o backend
-// expor agregacao, trocar isso por uma chamada dedicada e parar de truncar.
+// Sprint 1 nao tem endpoint dedicado de agregacao (/leads/stats), entao puxamos
+// um teto bem acima da expectativa real por vendedor.
 const HERO_FETCH_LIMIT = 200;
 const GREETING_REFRESH_MS = 60_000;
 
@@ -60,8 +67,6 @@ export default function HomeScreen() {
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState<string>("");
-  // Reavalia o greeting periodicamente: sem isso o usuario que abre o app as 11h55
-  // ve "Bom dia" ate fechar e reabrir, mesmo passando do meio-dia.
   const [now, setNow] = useState(() => new Date());
 
   const load = useCallback(async () => {
@@ -113,6 +118,8 @@ export default function HomeScreen() {
   const topLeads = useMemo(() => leads.slice(0, TOP_VISIBLE), [leads]);
   const greeting = t(greetingKey(now.getHours()), { name: name || "" });
 
+  const showHero = !(error && leads.length === 0);
+
   return (
     <FlatList
       style={styles.container}
@@ -120,40 +127,39 @@ export default function HomeScreen() {
       keyExtractor={(l) => l.id}
       contentContainerStyle={styles.list}
       refreshControl={
-        <RefreshControl
-          refreshing={refreshing}
-          onRefresh={onRefresh}
-          tintColor={colors.primary}
-        />
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.text} />
       }
       ListHeaderComponent={
-        <View>
-          <ScreenHeader title={t("home.today")} subtitle={greeting.trim()} />
+        <View style={styles.header}>
+          {/* Label + Fraunces 40 greeting (Mailchimp pattern). */}
+          {/* Label minusculo + titulo Fraunces gigante (padrao Mailchimp). */}
+          <Text style={styles.labelCaps}>{t("home.today")}</Text>
+          <Text style={styles.heroTitle} numberOfLines={2}>
+            {greeting.trim()}
+          </Text>
 
-          {/*
-            Hero hides on initial error with no cached leads: rendering "0 / R$ 0"
-            mid-error reads as real numbers and panics the user. Once any data
-            arrived (e.g. refresh-after-success), keep it visible even if a later
-            refresh errors so stale-but-useful beats blank.
-            Hero some no erro inicial sem leads: "0 / R$ 0" parece dado real e
-            assusta. Com dados em cache, mantem mesmo num erro de refresh.
-          */}
-          {!(error && leads.length === 0) ? (
-            <Card style={styles.hero}>
-              <View style={styles.heroCol}>
-                <Text style={styles.heroLabel}>{t("home.hero.active_leads")}</Text>
-                <Text style={styles.heroValue}>{hero.activeLeads}</Text>
+          {showHero ? (
+            <GlassSurface variant="regular" radius={24} style={styles.heroCard}>
+              <View style={styles.heroInner}>
+                <View style={styles.heroCol}>
+                  <Text style={styles.heroLabel}>{t("home.hero.active_leads")}</Text>
+                  <Text style={styles.heroValue}>{hero.activeLeads}</Text>
+                </View>
+                <View style={styles.heroDivider} />
+                <View style={styles.heroCol}>
+                  <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
+                  <Text style={styles.heroValue}>
+                    {formatBRL(hero.pipelineBRL, { compact: true })}
+                  </Text>
+                </View>
               </View>
-              <View style={styles.heroDivider} />
-              <View style={styles.heroCol}>
-                <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
-                <Text style={styles.heroValue}>{formatBRL(hero.pipelineBRL, { compact: true })}</Text>
-              </View>
-            </Card>
+            </GlassSurface>
           ) : null}
 
           {error && leads.length > 0 ? (
-            <ErrorBanner message={error} onRetry={() => void load()} />
+            <View style={styles.errorWrap}>
+              <ErrorBanner message={error} onRetry={() => void load()} />
+            </View>
           ) : null}
 
           {initialLoading ? (
@@ -162,24 +168,30 @@ export default function HomeScreen() {
               <LeadCardSkeleton />
               <LeadCardSkeleton />
             </View>
+          ) : !initialLoading && topLeads.length > 0 ? (
+            <Text style={styles.sectionTitle}>{t("home.todays_leads")}</Text>
           ) : null}
         </View>
       }
       ListEmptyComponent={
         !initialLoading ? (
           error ? (
-            <EmptyState
-              icon="cloud-offline-outline"
-              title={t("home.error_title")}
-              description={error}
-              action={
-                <Button
-                  label={t("common.retry")}
-                  variant="secondary"
-                  onPress={() => void load()}
-                />
-              }
-            />
+            <View style={styles.emptyWrap}>
+              <EmptyState
+                icon="cloud-offline-outline"
+                title={t("home.error_title")}
+                description={error}
+              />
+              <Pressable
+                onPress={() => void load()}
+                style={({ pressed }) => [
+                  styles.retryPill,
+                  pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
+                ]}
+              >
+                <Text style={styles.retryPillLabel}>{t("common.retry")}</Text>
+              </Pressable>
+            </View>
           ) : (
             <EmptyState
               icon="briefcase-outline"
@@ -203,69 +215,101 @@ export default function HomeScreen() {
         ) : null
       }
       renderItem={({ item }) => (
-        <LeadCard
-          lead={item}
-          onPress={() =>
-            router.push({
-              pathname: "/lead/[id]",
-              // Hidrata o detalhe na hora pra evitar refetch de 200 leads. Veja lead/[id].tsx.
-              params: { id: item.id, lead: JSON.stringify(item) },
-            })
-          }
-        />
+        <View style={styles.leadItem}>
+          <LeadCard
+            lead={item}
+            onPress={() =>
+              router.push({
+                pathname: "/lead/[id]",
+                params: { id: item.id, lead: JSON.stringify(item) },
+              })
+            }
+          />
+        </View>
       )}
-      ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
     />
   );
 }
 
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { backgroundColor: c.bg },
-    list: { paddingBottom: spacing["4xl"] },
-    hero: {
+    container: { backgroundColor: "transparent" },
+    list: { paddingBottom: spacing["6xl"] },
+    header: {
+      paddingHorizontal: spacing["2xl"],
+      paddingTop: spacing["3xl"],
+      gap: spacing.md,
+    },
+    labelCaps: {
+      ...typography.labelCaps,
+      color: c.textMuted,
+    },
+    heroTitle: {
+      ...typography.hDisplay,
+      color: c.text,
+      marginBottom: spacing.lg,
+    },
+    heroCard: {
+      marginBottom: spacing["2xl"],
+    },
+    heroInner: {
       flexDirection: "row",
       alignItems: "stretch",
-      marginHorizontal: spacing.xl,
-      marginBottom: spacing.lg,
-      padding: spacing.lg,
+      padding: spacing.xl,
     },
     heroCol: { flex: 1, gap: spacing.xs },
     heroDivider: {
-      width: 1,
-      backgroundColor: c.separator,
-      marginHorizontal: spacing.md,
+      width: StyleSheet.hairlineWidth,
+      backgroundColor: c.glassBorder,
+      marginHorizontal: spacing.lg,
     },
     heroLabel: {
-      ...typography.label,
+      ...typography.labelCaps,
       color: c.textMuted,
-      textTransform: "uppercase",
     },
     heroValue: {
-      ...typography.mono,
-      fontSize: 28,
+      fontFamily: fontFamily.semibold,
+      fontSize: 32,
+      letterSpacing: -0.6,
       color: c.text,
-      fontWeight: "800",
-      letterSpacing: -0.3,
     },
-    skeletonStack: {
-      gap: spacing.md,
-      paddingHorizontal: spacing.xl,
+    errorWrap: { marginBottom: spacing.lg },
+    skeletonStack: { gap: spacing.md, marginTop: spacing.sm },
+    sectionTitle: {
+      ...typography.hSection,
+      color: c.text,
+      marginTop: spacing.sm,
+      marginBottom: spacing.xs,
+    },
+    leadItem: {
+      marginHorizontal: spacing["2xl"],
+      marginTop: spacing.md,
+    },
+    emptyWrap: { alignItems: "center", marginTop: spacing["2xl"], gap: spacing.lg },
+    retryPill: {
+      paddingVertical: spacing.md - 2,
+      paddingHorizontal: spacing["2xl"],
+      borderRadius: radius.pill,
+      backgroundColor: c.primary,
+    },
+    retryPillLabel: {
+      ...typography.body,
+      fontFamily: fontFamily.semibold,
+      color: c.primaryText,
     },
     seeAll: {
-      marginTop: spacing.lg,
-      marginHorizontal: spacing.xl,
+      marginTop: spacing.xl,
+      marginHorizontal: spacing["2xl"],
       paddingVertical: spacing.md,
-      borderRadius: radius.md,
-      borderWidth: 1,
-      borderColor: c.border,
-      backgroundColor: c.surface,
+      borderRadius: radius.pill,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: c.borderStrong,
       alignItems: "center",
     },
     seeAllLabel: {
       ...typography.caption,
-      fontWeight: "700",
-      color: c.primary,
+      fontFamily: fontFamily.semibold,
+      color: c.text,
     },
   });
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,25 @@
 import { Ionicons } from "@expo/vector-icons";
+import {
+  Fraunces_400Regular,
+  Fraunces_600SemiBold,
+  Fraunces_700Bold,
+} from "@expo-google-fonts/fraunces";
+import {
+  Inter_400Regular,
+  Inter_500Medium,
+  Inter_600SemiBold,
+  Inter_700Bold,
+} from "@expo-google-fonts/inter";
 import { useFonts } from "expo-font";
 import { Stack, useRouter, useSegments } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { StyleSheet, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useEffect, useState } from "react";
 
 import "@/i18n";
 import { IntroVideo } from "@/components/ui/IntroVideo";
+import { MeshBackground } from "@/components/ui/MeshBackground";
 import { LocaleProvider } from "@/context/LocaleContext";
 import { ThemeProvider, useTheme } from "@/context/ThemeContext";
 import { supabase } from "@/lib/supabase";
@@ -29,9 +42,20 @@ function RootStack() {
   const [introDone, setIntroDone] = useState(false);
   const [ready, setReady] = useState(false);
   const [session, setSession] = useState<Session | null>(null);
-  // Preload Ionicons so the first paint never shows empty glyph squares (FOIT).
-  // Pre-carrega Ionicons; sem isso, primeiro paint mostra quadrados vazios.
-  const [fontsLoaded] = useFonts(Ionicons.font);
+  // Preload Ionicons + Fraunces (display serif) + Inter (UI sans) so first
+  // paint never shows fallback fonts or empty glyph squares (FOIT).
+  // Pre-carrega Ionicons + Fraunces + Inter; sem isso, primeiro paint usa
+  // fonte de sistema e estraga a hierarquia tipografica.
+  const [fontsLoaded] = useFonts({
+    ...Ionicons.font,
+    Fraunces_400Regular,
+    Fraunces_600SemiBold,
+    Fraunces_700Bold,
+    Inter_400Regular,
+    Inter_500Medium,
+    Inter_600SemiBold,
+    Inter_700Bold,
+  });
 
   // Auth check runs in parallel with the intro — whichever finishes later unblocks the router.
   // Verificacao de sessao roda em paralelo com a intro — o mais lento destrava o router.
@@ -47,16 +71,22 @@ function RootStack() {
   useGuardedRedirect(ready && introDone && themeHydrated, session);
 
   return (
-    <>
+    <View style={styles.root}>
       <StatusBar style={mode === "dark" ? "light" : "dark"} />
+      {/* Mesh sits behind every route so glass surfaces have texture to blur. */}
+      {/* Mesh fica atras de tudo pra o glass ter algo pra borrar. */}
+      <MeshBackground />
       {!introDone ? (
         <IntroVideo onFinished={() => setIntroDone(true)} />
       ) : !ready || !themeHydrated || !fontsLoaded ? null : (
         <Stack
           screenOptions={{
-            headerStyle: { backgroundColor: colors.bg },
+            // contentStyle transparent so MeshBackground shows through every route.
+            // contentStyle transparente: deixa o MeshBackground aparecer atras.
+            headerStyle: { backgroundColor: "transparent" },
+            headerTransparent: true,
             headerTintColor: colors.text,
-            contentStyle: { backgroundColor: colors.bg },
+            contentStyle: { backgroundColor: "transparent" },
           }}
         >
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
@@ -64,9 +94,13 @@ function RootStack() {
           <Stack.Screen name="lead/[id]" options={{ title: "Lead" }} />
         </Stack>
       )}
-    </>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+});
 
 // useGuardedRedirect sends unauthenticated users to /login and authenticated
 // users away from /login to the tab root.

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,5 +1,13 @@
+// Login — Glass Minimalist redesign (Fase 2, screen 1/6).
+// Inputs are intentionally inline (not the shared Input component) per the
+// "screen-by-screen first, componentize later" workflow. Same goes for the
+// CTA — bare Pressable pill instead of the shared Button.
+//
+// Login redesenhado: inputs underline + pill CTA inline (sem componentes).
+
 import { useMemo, useRef, useState } from "react";
 import {
+  ActivityIndicator,
   Animated,
   KeyboardAvoidingView,
   Platform,
@@ -7,21 +15,20 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
-import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
 import { Toast, type ToastVariant } from "@/components/ui/Toast";
 import { useTheme } from "@/context/ThemeContext";
 import { useFadeIn } from "@/hooks/useFadeIn";
 import { useShake } from "@/hooks/useShake";
 import { signInWithEmail } from "@/lib/auth";
 import { haptic } from "@/lib/haptics";
-import { fontWeight, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { fontFamily, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 import {
   validateEmail,
   validatePassword,
@@ -50,8 +57,6 @@ export default function LoginScreen() {
   const { translateX, shake } = useShake();
   const { opacity, translateY } = useFadeIn(360);
 
-  // Scale-in for the header — sits on top of the fade. Subtle (0.96 -> 1).
-  // Scale leve junto do fade pra entrada mais viva.
   const scale = useRef(new Animated.Value(0.96)).current;
   useMemo(() => {
     Animated.spring(scale, {
@@ -65,6 +70,8 @@ export default function LoginScreen() {
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [emailFocused, setEmailFocused] = useState(false);
+  const [passwordFocused, setPasswordFocused] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -118,7 +125,7 @@ export default function LoginScreen() {
       <ScrollView
         contentContainerStyle={[
           styles.scroll,
-          { paddingTop: insets.top + spacing["4xl"], paddingBottom: insets.bottom + spacing["2xl"] },
+          { paddingTop: insets.top + spacing["5xl"], paddingBottom: insets.bottom + spacing["3xl"] },
         ]}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
@@ -130,38 +137,41 @@ export default function LoginScreen() {
           ]}
         >
           <Text style={styles.brand}>FORD</Text>
-          <Text style={styles.title}>{t("app.name")}</Text>
-          <Text style={styles.subtitle}>{t("auth.subtitle")}</Text>
+          <Text style={styles.tagline}>{t("auth.subtitle")}</Text>
         </Animated.View>
 
-        <View style={styles.form}>
-          <Input
+        <Animated.View style={[styles.form, { transform: [{ translateX }] }]}>
+          <UnderlineInput
+            colors={colors}
             label={t("auth.email")}
-            placeholder={t("auth.email_placeholder")}
-            icon="mail-outline"
             value={email}
             onChangeText={setEmail}
+            placeholder={t("auth.email_placeholder")}
             keyboardType="email-address"
             autoCapitalize="none"
             autoCorrect={false}
             autoComplete="email"
-            shakeAnim={translateX}
+            focused={emailFocused}
+            onFocus={() => setEmailFocused(true)}
+            onBlur={() => setEmailFocused(false)}
             error={
               visibleErrors.email
                 ? t(visibleErrors.email.key, visibleErrors.email.vars)
                 : undefined
             }
           />
-          <Input
+          <UnderlineInput
+            colors={colors}
             label={t("auth.password")}
-            placeholder="••••••"
-            icon="lock-closed-outline"
             value={password}
             onChangeText={setPassword}
+            placeholder="••••••"
             secureTextEntry
             autoCapitalize="none"
             autoComplete="password"
-            shakeAnim={translateX}
+            focused={passwordFocused}
+            onFocus={() => setPasswordFocused(true)}
+            onBlur={() => setPasswordFocused(false)}
             error={
               visibleErrors.password
                 ? t(visibleErrors.password.key, visibleErrors.password.vars)
@@ -170,30 +180,42 @@ export default function LoginScreen() {
           />
 
           {serverError ? (
-            <View style={styles.serverErrorBox}>
-              <Text style={styles.serverErrorText}>{serverError}</Text>
-            </View>
+            <Text style={styles.serverErrorText}>{serverError}</Text>
           ) : null}
+        </Animated.View>
 
-          <Button
-            label={t("auth.sign_in")}
-            loadingLabel={t("auth.signing_in")}
-            loading={loading}
-            disabled={buttonDisabled}
+        <View style={styles.footer}>
+          <Pressable
             onPress={onSubmit}
-            style={styles.submit}
-          />
-        </View>
+            disabled={buttonDisabled || loading}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: buttonDisabled || loading, busy: loading }}
+            style={({ pressed }) => [
+              styles.pillCTA,
+              (buttonDisabled || loading) && styles.pillCTADisabled,
+              pressed && styles.pillCTAPressed,
+            ]}
+          >
+            {loading ? (
+              <View style={styles.pillCTALoading}>
+                <ActivityIndicator color={colors.primaryText} />
+                <Text style={styles.pillCTALabel}>{t("auth.signing_in")}</Text>
+              </View>
+            ) : (
+              <Text style={styles.pillCTALabel}>{t("auth.sign_in")}</Text>
+            )}
+          </Pressable>
 
-        <Pressable
-          onPress={onForgotPassword}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel={t("auth.forgot_password")}
-          style={({ pressed }) => [styles.forgotWrap, pressed && { opacity: 0.6 }]}
-        >
-          <Text style={styles.forgotLabel}>{t("auth.forgot_password")}</Text>
-        </Pressable>
+          <Pressable
+            onPress={onForgotPassword}
+            hitSlop={12}
+            accessibilityRole="button"
+            accessibilityLabel={t("auth.forgot_password")}
+            style={({ pressed }) => [styles.forgotWrap, pressed && { opacity: 0.6 }]}
+          >
+            <Text style={styles.forgotLabel}>{t("auth.forgot_password")}</Text>
+          </Pressable>
+        </View>
       </ScrollView>
 
       <Toast
@@ -206,59 +228,143 @@ export default function LoginScreen() {
   );
 }
 
+// Inline minimal underline input. Lives here for now per the screen-by-screen
+// workflow; gets extracted to a shared <UnderlineInput> in Phase 3.
+type UnderlineInputProps = {
+  colors: ThemeColors;
+  label: string;
+  value: string;
+  onChangeText: (s: string) => void;
+  placeholder?: string;
+  focused: boolean;
+  onFocus: () => void;
+  onBlur: () => void;
+  error?: string;
+  secureTextEntry?: boolean;
+  keyboardType?: "default" | "email-address";
+  autoCapitalize?: "none" | "sentences";
+  autoCorrect?: boolean;
+  autoComplete?: "email" | "password";
+};
+
+function UnderlineInput({
+  colors,
+  label,
+  value,
+  onChangeText,
+  placeholder,
+  focused,
+  onFocus,
+  onBlur,
+  error,
+  secureTextEntry,
+  keyboardType,
+  autoCapitalize,
+  autoCorrect,
+  autoComplete,
+}: UnderlineInputProps) {
+  const lineColor = error ? colors.error : focused ? colors.text : colors.border;
+  return (
+    <View style={inputStyles.wrap}>
+      <Text style={[inputStyles.label, { color: colors.textMuted }]}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.textSubtle}
+        secureTextEntry={secureTextEntry}
+        keyboardType={keyboardType}
+        autoCapitalize={autoCapitalize}
+        autoCorrect={autoCorrect}
+        autoComplete={autoComplete}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        style={[
+          inputStyles.input,
+          { color: colors.text, borderBottomColor: lineColor },
+        ]}
+      />
+      {error ? (
+        <Text style={[inputStyles.error, { color: colors.error }]}>{error}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const inputStyles = StyleSheet.create({
+  wrap: { marginBottom: spacing.xl },
+  label: {
+    ...typography.labelCaps,
+    marginBottom: spacing.xs,
+  },
+  input: {
+    ...typography.bodyLg,
+    paddingVertical: spacing.sm + 2,
+    borderBottomWidth: StyleSheet.hairlineWidth + 0.5,
+  },
+  error: {
+    ...typography.caption,
+    marginTop: spacing.xs,
+  },
+});
+
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { flex: 1, backgroundColor: c.bg },
+    // Transparent so the MeshBackground at the root shows through.
+    container: { flex: 1, backgroundColor: "transparent" },
     scroll: {
       flexGrow: 1,
-      paddingHorizontal: spacing.xl,
-      justifyContent: "center",
+      paddingHorizontal: spacing["2xl"],
+      justifyContent: "space-between",
     },
     header: {
-      alignItems: "center",
-      marginBottom: spacing["2xl"],
-      gap: spacing.xs,
+      alignItems: "flex-start",
+      marginBottom: spacing["4xl"],
+      gap: spacing.lg,
     },
     brand: {
-      fontSize: 40,
-      fontWeight: fontWeight.extrabold,
-      letterSpacing: 6,
-      color: c.primary,
-      marginBottom: spacing.md,
+      fontFamily: fontFamily.bold,
+      fontSize: 72,
+      letterSpacing: 8,
+      color: c.text,
+      lineHeight: 72,
     },
-    title: { ...typography.h1, color: c.text },
-    subtitle: {
-      ...typography.body,
+    tagline: {
+      ...typography.bodyLg,
       color: c.textMuted,
-      textAlign: "center",
-      paddingHorizontal: spacing.lg,
+      maxWidth: 320,
     },
     form: { width: "100%" },
-    serverErrorBox: {
-      borderWidth: 1,
-      borderColor: c.error,
-      backgroundColor: c.errorSoft,
-      borderRadius: radius.md,
-      padding: spacing.md,
-      marginTop: spacing.xs,
-      marginBottom: spacing.md,
-    },
     serverErrorText: {
       ...typography.caption,
-      fontWeight: "600",
       color: c.error,
-      textAlign: "center",
+      marginTop: spacing.sm,
     },
-    submit: { marginTop: spacing.md },
+    footer: { gap: spacing.sm, marginTop: spacing["3xl"] },
+    pillCTA: {
+      height: 56,
+      borderRadius: radius.pill,
+      backgroundColor: c.primary,
+      alignItems: "center",
+      justifyContent: "center",
+      flexDirection: "row",
+    },
+    pillCTADisabled: { opacity: 0.45 },
+    pillCTAPressed: { opacity: 0.92, transform: [{ scale: 0.98 }] },
+    pillCTALoading: { flexDirection: "row", alignItems: "center", gap: spacing.sm },
+    pillCTALabel: {
+      ...typography.bodyLg,
+      fontFamily: fontFamily.semibold,
+      color: c.primaryText,
+    },
     forgotWrap: {
       alignItems: "center",
       paddingVertical: spacing.lg,
-      marginTop: spacing.md,
     },
     forgotLabel: {
       ...typography.caption,
-      color: c.primary,
-      fontWeight: "600",
+      fontFamily: fontFamily.medium,
+      color: c.textMuted,
     },
   });
 }

--- a/components/domain/LeadCard.tsx
+++ b/components/domain/LeadCard.tsx
@@ -5,15 +5,15 @@
 //   1. Priority chip (colored, uppercase) on the left + relative time on the right
 //   2. VIN in mono semibold
 //   3. Reason in body textMuted (optional)
-//   4. Status dot + label on the left + expected value (mono, primary color) on the right
-// Pressable wraps the whole thing; haptic light on press; scale 0.99 on press.
-// Card de lead na lista: stripe + chip + VIN mono + razao + status + valor.
+//   4. Status dot + label on the left + expected value (mono primary text) on the right
+// Wrapped in GlassSurface (thin variant) so it sits on top of the mesh bg.
+// Card de lead: stripe + chip + VIN mono + razao + status + valor sobre glass.
 
 import React, { useMemo, useRef } from "react";
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
-import { Card } from "@/components/ui/Card";
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { useTheme } from "@/context/ThemeContext";
 import { haptic } from "@/lib/haptics";
 import type { Lead } from "@/lib/api";
@@ -64,7 +64,7 @@ export function LeadCard({ lead, onPress }: LeadCardProps) {
   };
 
   const cardBody = (
-    <Card style={styles.card}>
+    <GlassSurface variant="thin" radius={18} style={styles.card}>
       <View style={[styles.stripe, { backgroundColor: priority.color }]} />
       <View style={styles.body}>
         <View style={styles.row}>
@@ -104,7 +104,7 @@ export function LeadCard({ lead, onPress }: LeadCardProps) {
           ) : null}
         </View>
       </View>
-    </Card>
+    </GlassSurface>
   );
 
   if (!onPress) return cardBody;
@@ -197,7 +197,7 @@ function createStyles(c: ThemeColors) {
     },
     value: {
       ...typography.mono,
-      color: c.primary,
+      color: c.text,
       fontWeight: "700",
     },
   });

--- a/components/ui/GlassSurface.tsx
+++ b/components/ui/GlassSurface.tsx
@@ -1,0 +1,84 @@
+// Glass surface — semi-transparent + blur. Abstraction over platform diffs:
+//   iOS / web   -> expo-blur BlurView (web: backdrop-filter via the lib)
+//   Android     -> rgba fill only (real blur is jank in long lists on Android)
+//
+// Variants control blur intensity + opacity. Use `regular` by default,
+// `thin` for nested surfaces, `thick` for sheets and modals.
+//
+// Superficie glass: blur real no iOS/web; fill rgba no Android (perf).
+
+import { useMemo, type ReactNode } from "react";
+import { Platform, StyleSheet, View, type ViewStyle } from "react-native";
+import { BlurView } from "expo-blur";
+
+import { useTheme } from "@/context/ThemeContext";
+
+export type GlassVariant = "thin" | "regular" | "thick";
+
+export interface GlassSurfaceProps {
+  variant?: GlassVariant;
+  radius?: number;
+  border?: boolean;
+  style?: ViewStyle | ViewStyle[];
+  children?: ReactNode;
+}
+
+const INTENSITY: Record<GlassVariant, number> = {
+  thin: 30,
+  regular: 60,
+  thick: 90,
+};
+
+// Android falls back to fill-only — these alphas keep parity with the visual
+// weight of the blur intensities above.
+const ANDROID_ALPHA: Record<GlassVariant, number> = {
+  thin: 0.45,
+  regular: 0.6,
+  thick: 0.78,
+};
+
+export function GlassSurface({
+  variant = "regular",
+  radius = 20,
+  border = true,
+  style,
+  children,
+}: GlassSurfaceProps) {
+  const { colors, mode } = useTheme();
+
+  const containerStyle = useMemo<ViewStyle>(
+    () => ({
+      borderRadius: radius,
+      overflow: "hidden",
+      borderWidth: border ? StyleSheet.hairlineWidth : 0,
+      borderColor: colors.glassBorder,
+      backgroundColor: Platform.OS === "android" ? androidFill(mode, variant) : "transparent",
+    }),
+    [radius, border, colors.glassBorder, mode, variant],
+  );
+
+  if (Platform.OS === "android") {
+    return <View style={[containerStyle, style]}>{children}</View>;
+  }
+
+  // BlurView for iOS + web (expo-blur uses backdrop-filter on web).
+  // tint='default' adapts to theme; we pass dark/light explicitly so the
+  // glass reads correctly even when device theme disagrees with app theme.
+  return (
+    <View style={[containerStyle, style]}>
+      <BlurView
+        intensity={INTENSITY[variant]}
+        tint={mode === "dark" ? "dark" : "light"}
+        style={StyleSheet.absoluteFill}
+      />
+      {children}
+    </View>
+  );
+}
+
+function androidFill(mode: "light" | "dark", variant: GlassVariant): string {
+  const alpha = ANDROID_ALPHA[variant];
+  return mode === "dark"
+    ? `rgba(40, 40, 40, ${alpha})`
+    : `rgba(255, 255, 255, ${alpha})`;
+}

--- a/components/ui/MeshBackground.tsx
+++ b/components/ui/MeshBackground.tsx
@@ -1,0 +1,61 @@
+// Mesh gradient background — fixed at the root, sits behind every screen so
+// the glass surfaces have texture to blur into. Three radial-style layers
+// (top-left, top-right, bottom) over a flat base color. Static, no animation.
+//
+// Bg mesh fixo no root: 3 camadas de gradiente sobre cor base. Sem animacao.
+
+import { useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+import { useTheme } from "@/context/ThemeContext";
+
+type MeshConfig = {
+  base: string;
+  topLeft: [string, string];
+  topRight: [string, string];
+  bottom: [string, string];
+};
+
+const MESH: Record<"light" | "dark", MeshConfig> = {
+  dark: {
+    base: "#161616",
+    topLeft: ["rgba(40, 40, 55, 0.35)", "rgba(40, 40, 55, 0)"],
+    topRight: ["rgba(60, 40, 40, 0.20)", "rgba(60, 40, 40, 0)"],
+    bottom: ["rgba(30, 30, 35, 0)", "rgba(22, 22, 22, 0.45)"],
+  },
+  light: {
+    base: "#F0F0F2",
+    topLeft: ["rgba(220, 220, 235, 0.50)", "rgba(220, 220, 235, 0)"],
+    topRight: ["rgba(245, 240, 235, 0.35)", "rgba(245, 240, 235, 0)"],
+    bottom: ["rgba(240, 240, 242, 0)", "rgba(240, 240, 242, 0.40)"],
+  },
+};
+
+export function MeshBackground() {
+  const { mode } = useTheme();
+  const cfg = useMemo(() => MESH[mode], [mode]);
+
+  return (
+    <View style={[StyleSheet.absoluteFill, { backgroundColor: cfg.base }]} pointerEvents="none">
+      <LinearGradient
+        colors={cfg.topLeft}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0.7, y: 0.6 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={cfg.topRight}
+        start={{ x: 1, y: 0 }}
+        end={{ x: 0.3, y: 0.6 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={cfg.bottom}
+        start={{ x: 0.5, y: 0.4 }}
+        end={{ x: 0.5, y: 1 }}
+        style={StyleSheet.absoluteFill}
+      />
+    </View>
+  );
+}

--- a/docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
+++ b/docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
@@ -1,0 +1,212 @@
+# Glass Minimalist — Design System Spec
+
+**Data:** 2026-05-23
+**Autor:** Jota + Claude Opus 4.7
+**Status:** approved, em implementacao
+
+## Motivacao
+
+O design anterior (Ford Blue agressivo + cards solidos + tipografia sans-only) nao alcancou o look minimalista premium que o produto pede. Refs visuais aprovados:
+
+- **Base estetica** (Mailchimp / Mobbin): label-caps minusculo + titulo serif gigante, hierarquia hiper-clara, cards com bordas leves, muito espaco em branco.
+- **Camada glass** (TIDE app): superficies semi-transparentes com blur ("frosted glass"), bg dark sutil quase preto, icones outline finos, CTAs brancos pill.
+
+Objetivo: combinar **Mailchimp em hierarquia tipografica** + **TIDE em superficies glass** sob a marca Ford (reduzida ao logo).
+
+## Decisoes fechadas
+
+| | Decisao |
+|---|---|
+| Modos | Light + dark com paridade total. Dark e a estrela. |
+| Ford Blue | So no wordmark/logo. UI = grayscale + branco. CTAs brancos (pill) em dark, pretos (pill) em light. |
+| Fontes | Fraunces (display serif variable) + Inter (sans body) via expo-google-fonts |
+| Glass | Agressivo (TIDE-style): cards, inputs, hero, tab bar, modais. Tudo |
+| BG | Mesh gradient abstrato estatico (sem foto, sem animacao). 3 radial gradients sobrepostos |
+
+## Tokens de cor
+
+### Dark
+```
+bg               #1E1E1E    (RGB 30,30,30 — pedido explicito)
+bgDeep           #161616    (sutilmente mais escuro pra mesh)
+bgElevated       #252525    (cards solidos elevados, fallback sem glass)
+glassBase        rgba(40,40,40,0.55)    + backdrop-blur 24px
+glassBorder      rgba(255,255,255,0.08)
+textPrimary      #F5F5F5    (nao puro branco)
+textMuted        #9CA3AF
+textSubtle       #6B7280
+separator        rgba(255,255,255,0.06)
+```
+
+### Light
+```
+bg               #FAFAFA    (off-white)
+bgDeep           #F0F0F2
+bgElevated       #FFFFFF
+glassBase        rgba(255,255,255,0.65)    + backdrop-blur 24px
+glassBorder      rgba(0,0,0,0.06)
+textPrimary      #1A1A1A
+textMuted        #6B7280
+textSubtle       #9CA3AF
+separator        rgba(0,0,0,0.05)
+```
+
+### Brand + semantic (compartilhado)
+```
+fordBlue         #003478    APENAS wordmark/logo. NUNCA UI.
+ctaDark          #FFFFFF    pill branco em dark
+ctaLight         #1A1A1A    pill preto em light
+success          #10B981
+warning          #F59E0B
+error            #EF4444
+critical         #FF453A    (Apple red)
+```
+
+## Tipografia
+
+```
+Display:  Fraunces (variable 100-900, soft, opt-sized)
+Body:     Inter (variable 100-900)
+Mono:     SF Mono / Cascadia / Consolas (system stack, sem bundle)
+
+Escala:
+  h-display    40px  Fraunces 700  letter-spacing -1.2   titulos de tela
+  h-section    28px  Fraunces 600  letter-spacing -0.8   section headers
+  h3           18px  Inter 600                            subsections
+  body-lg      17px  Inter 400                            paragraphs
+  body         15px  Inter 400                            default
+  caption      13px  Inter 400
+  label-caps   11px  Inter 600     letter-spacing +1.0    Mailchimp uppercase
+  mono         15px  Mono 500
+```
+
+Bundle via `useFonts` em `_layout.tsx` (mesmo pattern de Ionicons).
+
+## Sistema de glass
+
+Componente `<GlassSurface>` abstrai por plataforma:
+
+```
+iOS native:     expo-blur BlurView intensity=80 + tint='regular'|'dark'
+Android native: rgba fill semi-transparent + borda glassBorder
+                (Android blur real tem perf ruim em listas)
+Web:            backdrop-filter: blur(24px) + bg glassBase + borda
+```
+
+Variantes:
+- `thin` — blur 12px, mais transparente, pra surfaces aninhadas
+- `regular` — blur 24px, padrao
+- `thick` — blur 40px, modais e sheets
+
+API:
+```tsx
+<GlassSurface variant="regular" radius={20}>
+  {children}
+</GlassSurface>
+```
+
+## Mesh gradient background
+
+Componente `<MeshBackground>` fixo no root, atras de tudo. Implementacao: `expo-linear-gradient` em 3 layers absoluteFill.
+
+```
+Dark:
+  base:        #161616
+  layer 1:     top-left,   rgba(40,40,55,0.35)  -> transparent
+  layer 2:     top-right,  rgba(60,40,40,0.20)  -> transparent
+  layer 3:     bottom,     rgba(30,30,35,0.45)  -> bgDeep
+
+Light:
+  base:        #F0F0F2
+  layer 1:     top-left,   rgba(220,220,235,0.50) -> transparent
+  layer 2:     top-right,  rgba(245,240,235,0.35) -> transparent
+  layer 3:     bottom,     rgba(240,240,242,0.40) -> bgDeep
+```
+
+## Padroes por tela
+
+### Login
+- bg mesh + wordmark **FORD** Fraunces 56px branco
+- tagline Inter 15px muted abaixo
+- inputs underline-only (sem borda completa, sem card glass) — minimalista
+- CTA branco pill bottom + Esqueci senha em ghost
+
+### Home
+```
+[mesh bg]
+  HOJE                           label-caps 11
+  Bom dia, Jota                  Fraunces 40
+  ┌─────────────── glass ───────────────┐
+  │  LEADS ATIVOS    PIPELINE           │
+  │       12         R$ 1.2M            │
+  └─────────────────────────────────────┘
+  Leads recentes                 Fraunces 28
+  [glass card lead 1]
+  [glass card lead 2]
+  ...
+  [tab bar glass thick]
+```
+
+### Leads
+- Mesmo header pattern (label-caps + Fraunces titulo)
+- Search bar glass pill
+- Filter chips glass (active = solid white com text dark)
+- Lista de glass cards
+
+### Profile
+- Avatar 80px circular + nome Fraunces 28px + email Inter muted
+- Sections com label-caps + glass rows separadas por separator
+- Sem card wrapper, rows ficam direto sobre o mesh com glass
+
+### Lead detail
+- Header stack minimo
+- Label-caps `LEAD` + VIN mono grande
+- Status pill colored (mantem palette de status)
+- Glass sections de info
+- Footer fixed glass thick com 3 CTAs
+
+### Tab bar
+- Glass thick com 4 icones outline finos + 1 central destacado
+- Sem labels (ou labels so no active, estilo iOS)
+
+## Ordem de implementacao
+
+### Fase 1 — Foundation (1 PR)
+- `theme.ts`: novas paletas dark/light com tokens acima
+- `_layout.tsx`: useFonts(Fraunces + Inter)
+- `components/ui/MeshBackground.tsx`: novo componente fixo no root
+- `components/ui/GlassSurface.tsx`: novo componente com abstracao de blur
+
+### Fase 2 — Telas, 1 PR por tela, sem componentizar
+Estilos copiados inline em cada tela. Componentizacao vem depois.
+
+1. Login
+2. Home
+3. Leads
+4. Profile
+5. Lead detail
+6. Tab bar (glass)
+
+### Fase 3 — Componentizacao
+Depois que todas as telas estiverem certas:
+- `<ScreenTitle>` — label-caps + Fraunces titulo + opt subtitle
+- `<GlassCard>` — wrapper com variantes thin/regular/thick
+- `<PillButton>` — variantes solid/glass/ghost com pill radius
+- Refatorar telas pra usar novos componentes
+
+## Migracao das telas existentes
+
+Telas atuais ja tem:
+- ScreenHeader (deprecate por ScreenTitle na fase 3)
+- Card (deprecate por GlassCard na fase 3)
+- Button (manter, ganha variante `pill`)
+- ErrorBanner, EmptyState, Toast — mantem, ganham GlassSurface por dentro
+
+i18n keys nao mudam (so visuals).
+
+## Riscos e mitigacoes
+
+- **Performance do blur no Android**: usar fallback rgba semi-transparent. Testar em emulador antes de mergear cada PR.
+- **Bundle size das fontes**: Fraunces + Inter variable ~400KB combinado. Aceitavel pra UX premium.
+- **Web fallback do blur**: `backdrop-filter` tem suporte ~95% (caniuse). Browsers antigos veem rgba sem blur — degradacao OK.
+- **Mesh gradient em listas longas**: fixed atras de tudo, nao re-renderiza. Performance neutra.

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,28 +1,39 @@
-// Design tokens for the ForwardService mobile app.
-// Two palettes (light + dark) keyed by semantic tokens. Screens consume via
-// useTheme() — never import `palette` directly.
-// Tokens de design: paletas light/dark, espacamento, tipografia, elevacao.
+// Design tokens for the ForwardService mobile app — Glass Minimalist redesign.
+// Light + dark palettes keyed by semantic tokens. Screens consume via useTheme().
+// Spec: docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
+//
+// Tokens de design: paletas light/dark, glass, tipografia Fraunces+Inter.
 
 import { Platform } from "react-native";
 
 export type ThemeMode = "light" | "dark";
 
 export type ThemeColors = {
+  // Base surfaces
   bg: string;
+  bgDeep: string;
   bgElevated: string;
   surface: string;
   surfaceElevated: string;
   surfaceHover: string;
+  // Glass (new): semi-transparent, paired with backdrop-blur at the consumer.
+  glassBase: string;
+  glassBorder: string;
+  // Borders + separators
   border: string;
   borderStrong: string;
   separator: string;
+  // Text
   text: string;
   textMuted: string;
   textSubtle: string;
+  // Primary CTA — white pill in dark, dark pill in light (TIDE-style).
+  // Brand fordBlue is exported separately and used ONLY in the wordmark.
   primary: string;
   primaryDeep: string;
   primaryText: string;
   primarySoft: string;
+  // Status / semantic
   success: string;
   successSoft: string;
   warning: string;
@@ -30,36 +41,38 @@ export type ThemeColors = {
   error: string;
   errorSoft: string;
   critical: string;
+  // Misc
   overlay: string;
   tabBar: string;
   inputBg: string;
 };
 
-// Ford Blue is the brand primary. Light uses the classic deep blue; dark uses
-// a lighter, more saturated variant for legibility on dark backgrounds.
-// Azul Ford classico (#003478) no light; variante mais clara no dark.
+// Ford Blue is the brand mark. Used ONLY on the FORD wordmark + logo glyph.
+// Never on CTAs, switches, tabs, or any interactive surface.
+// Azul Ford apenas no wordmark/logo. Nunca em UI interativa.
 export const FORD_BLUE = "#003478";
 export const FORD_BLUE_DEEP = "#002356";
-export const FORD_BLUE_DARK_MODE = "#5B8DEF";
-export const FORD_BLUE_DARK_MODE_DEEP = "#3D6FCC";
 
 export const palette: Record<ThemeMode, ThemeColors> = {
   light: {
-    bg: "#F7F8FA",
+    bg: "#FAFAFA",
+    bgDeep: "#F0F0F2",
     bgElevated: "#FFFFFF",
     surface: "#FFFFFF",
     surfaceElevated: "#FFFFFF",
-    surfaceHover: "#F1F3F7",
-    border: "rgba(11, 18, 32, 0.08)",
-    borderStrong: "rgba(11, 18, 32, 0.14)",
-    separator: "rgba(11, 18, 32, 0.05)",
-    text: "#0B1220",
-    textMuted: "#56627A",
-    textSubtle: "#8E97AC",
-    primary: FORD_BLUE,
-    primaryDeep: FORD_BLUE_DEEP,
-    primaryText: "#FFFFFF",
-    primarySoft: "rgba(0, 52, 120, 0.10)",
+    surfaceHover: "#F4F4F6",
+    glassBase: "rgba(255, 255, 255, 0.65)",
+    glassBorder: "rgba(0, 0, 0, 0.06)",
+    border: "rgba(0, 0, 0, 0.08)",
+    borderStrong: "rgba(0, 0, 0, 0.14)",
+    separator: "rgba(0, 0, 0, 0.05)",
+    text: "#1A1A1A",
+    textMuted: "#6B7280",
+    textSubtle: "#9CA3AF",
+    primary: "#1A1A1A",
+    primaryDeep: "#000000",
+    primaryText: "#FAFAFA",
+    primarySoft: "rgba(26, 26, 26, 0.06)",
     success: "#0F8A5F",
     successSoft: "rgba(15, 138, 95, 0.10)",
     warning: "#B5670A",
@@ -68,48 +81,56 @@ export const palette: Record<ThemeMode, ThemeColors> = {
     errorSoft: "rgba(199, 54, 58, 0.10)",
     critical: "#A11A20",
     overlay: "rgba(11, 18, 32, 0.40)",
-    tabBar: "rgba(255, 255, 255, 0.92)",
-    inputBg: "#FFFFFF",
+    tabBar: "rgba(255, 255, 255, 0.78)",
+    inputBg: "rgba(255, 255, 255, 0.60)",
   },
   dark: {
-    bg: "#0B1220",
-    bgElevated: "#101A2E",
-    surface: "#121A2B",
-    surfaceElevated: "#1A2336",
-    surfaceHover: "#1F2A40",
+    bg: "#1E1E1E",
+    bgDeep: "#161616",
+    bgElevated: "#252525",
+    surface: "#252525",
+    surfaceElevated: "#2A2A2A",
+    surfaceHover: "#303030",
+    glassBase: "rgba(40, 40, 40, 0.55)",
+    glassBorder: "rgba(255, 255, 255, 0.08)",
     border: "rgba(255, 255, 255, 0.07)",
     borderStrong: "rgba(255, 255, 255, 0.12)",
-    separator: "rgba(255, 255, 255, 0.05)",
-    text: "#E6EDF7",
-    textMuted: "#93A1B8",
-    textSubtle: "#6C7A95",
-    primary: FORD_BLUE_DARK_MODE,
-    primaryDeep: FORD_BLUE_DARK_MODE_DEEP,
-    primaryText: "#FFFFFF",
-    primarySoft: "rgba(91, 141, 239, 0.16)",
+    separator: "rgba(255, 255, 255, 0.06)",
+    text: "#F5F5F5",
+    textMuted: "#9CA3AF",
+    textSubtle: "#6B7280",
+    primary: "#FAFAFA",
+    primaryDeep: "#E5E5E5",
+    primaryText: "#1A1A1A",
+    primarySoft: "rgba(250, 250, 250, 0.10)",
     success: "#2DB67B",
     successSoft: "rgba(45, 182, 123, 0.16)",
     warning: "#E3A93C",
     warningSoft: "rgba(227, 169, 60, 0.16)",
     error: "#E5484D",
     errorSoft: "rgba(229, 72, 77, 0.16)",
-    critical: "#FF5463",
+    critical: "#FF453A",
     overlay: "rgba(0, 0, 0, 0.6)",
-    tabBar: "rgba(11, 18, 32, 0.85)",
-    inputBg: "#121A2B",
+    tabBar: "rgba(30, 30, 30, 0.72)",
+    inputBg: "rgba(40, 40, 40, 0.55)",
   },
 };
 
+// Font families — Fraunces (display serif) + Inter (sans body) loaded via
+// expo-google-fonts in _layout.tsx. Names below match the package exports.
+// Mono uses system stack (no bundle), with proper Windows fallback.
+// Fontes: Fraunces + Inter via @expo-google-fonts; mono fica em system stack.
 export const fontFamily = {
-  regular: "System",
-  medium: "System",
-  semibold: "System",
-  bold: "System",
-  extrabold: "System",
-  // Web fallback list ordered for legibility on Windows/macOS/Linux: native
-  // monos first, then bundled-with-Windows Cascadia/Consolas. Bare "ui-monospace"
-  // collapsed to a chunky serif on Windows.
-  // Stack ordenada por sistema: Windows nao tem SF Mono, entao precisa de Cascadia/Consolas.
+  // Display serif (Fraunces) — for h-display + h-section.
+  displayRegular: "Fraunces_400Regular",
+  displaySemibold: "Fraunces_600SemiBold",
+  displayBold: "Fraunces_700Bold",
+  // Sans body (Inter) — for body, captions, labels, mono fallback.
+  regular: "Inter_400Regular",
+  medium: "Inter_500Medium",
+  semibold: "Inter_600SemiBold",
+  bold: "Inter_700Bold",
+  // Mono stack (system).
   mono: Platform.select({
     ios: "Menlo",
     android: "monospace",
@@ -118,9 +139,9 @@ export const fontFamily = {
   }) as string,
 } as const;
 
-// Weight tokens — paired with fontFamily.System on RN to get bold variants
-// without bundling custom fonts. When we ship Manrope/Inter later, swap families.
-// Pesos: enquanto nao ha fonte custom, usa system + fontWeight numerico.
+// Numeric weights kept for any caller that still spreads typography helpers.
+// React Native maps these to the loaded font weights automatically when the
+// fontFamily explicitly carries the weight (e.g. Inter_600SemiBold).
 export const fontWeight = {
   regular: "400",
   medium: "500",
@@ -139,8 +160,8 @@ export const fontSize = {
   "2xl": 22,
   "3xl": 28,
   "4xl": 32,
-  "5xl": 48,
-  "6xl": 72,
+  "5xl": 40,
+  "6xl": 56,
 } as const;
 
 export const spacing = {
@@ -176,8 +197,9 @@ export const letterSpacing = {
   ultra: 6,
 } as const;
 
-// Elevation pra light: sombras reais (iOS shadow* + Android elevation).
-// Hierarquia visual depende da luz vinda de cima.
+// Elevation light: real shadows. Elevation dark: subtle top-highlight only
+// (shadows on dark turn into smudges; Vercel/Cursor pattern).
+// Glass surfaces dont use either — they get a thin border via glassBorder.
 export const elevationLight = {
   none: {
     shadowColor: "transparent",
@@ -208,7 +230,7 @@ export const elevationLight = {
     elevation: 4,
   },
   primary: {
-    shadowColor: FORD_BLUE,
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.16,
     shadowRadius: 12,
@@ -216,8 +238,6 @@ export const elevationLight = {
   },
 } as const;
 
-// Elevation pra dark: zero sombra. Hierarquia via top-highlight (borda superior
-// clarinha). Estetica Vercel/Cursor — sombras em fundo escuro viram manchas.
 export const elevationDark = {
   none: {},
   sm: { borderTopColor: "rgba(255,255,255,0.04)", borderTopWidth: 1 },
@@ -226,9 +246,6 @@ export const elevationDark = {
   primary: { borderTopColor: "rgba(255,255,255,0.10)", borderTopWidth: 1 },
 } as const;
 
-// Semantic elevation aliases — usar nas telas em vez de sm/md/lg/primary direto.
-// Card = elemento normal. Sheet = modal/bottom-sheet. Popover = floating action.
-// Aliases semanticos: card / sheet / popover.
 export const elevationAliasLight = {
   card: elevationLight.sm,
   sheet: elevationLight.lg,
@@ -243,27 +260,74 @@ export const elevationAliasDark = {
 
 export type Elevation = typeof elevationLight | typeof elevationDark;
 
-// Typography helpers que combinam size + weight + lineHeight em um objeto
-// pronto pra spread. Substitui o `typography.h1` antigo, agora tema-aware
-// no consumer (cor vem de useTheme()).
-// Helpers de tipografia: spread direto no style.
+// Typography helpers — Fraunces for display, Inter for everything else.
+// Spread directly into a Text style. Color comes from useTheme() at the
+// consumer (these helpers are color-agnostic).
+//
+// Display = page titles, section titles. Heavy serif presence.
+// Body / caption / label = all Inter for UI consistency.
+// Tipografia: Fraunces no display, Inter no resto. Cor vem do consumer.
 export const typography = {
-  h1: {
+  // Display — Fraunces serif.
+  hDisplay: {
+    fontFamily: fontFamily.displayBold,
+    fontSize: fontSize["5xl"],
+    lineHeight: 44,
+    letterSpacing: -1.2,
+  },
+  hSection: {
+    fontFamily: fontFamily.displaySemibold,
     fontSize: fontSize["3xl"],
-    fontWeight: fontWeight.extrabold,
-    lineHeight: 34,
-    letterSpacing: -0.4,
+    lineHeight: 32,
+    letterSpacing: -0.8,
+  },
+  // Legacy aliases (h1/h2) so screens not yet migrated keep working.
+  // Aliases legados pra telas ainda nao migradas.
+  h1: {
+    fontFamily: fontFamily.displayBold,
+    fontSize: fontSize["5xl"],
+    lineHeight: 44,
+    letterSpacing: -1.2,
   },
   h2: {
-    fontSize: fontSize["2xl"],
-    fontWeight: fontWeight.bold,
-    lineHeight: 28,
-    letterSpacing: -0.3,
+    fontFamily: fontFamily.displaySemibold,
+    fontSize: fontSize["3xl"],
+    lineHeight: 32,
+    letterSpacing: -0.8,
   },
-  h3: { fontSize: fontSize.xl, fontWeight: fontWeight.semibold, lineHeight: 24 },
-  body: { fontSize: fontSize.lg, fontWeight: fontWeight.regular, lineHeight: 22 },
-  caption: { fontSize: fontSize.md, fontWeight: fontWeight.regular, lineHeight: 18 },
-  label: { fontSize: fontSize.sm, fontWeight: fontWeight.semibold, letterSpacing: 0.5 },
+  // Body — Inter sans.
+  h3: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.xl,
+    lineHeight: 24,
+  },
+  bodyLg: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.lg + 1,
+    lineHeight: 24,
+  },
+  body: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.lg,
+    lineHeight: 22,
+  },
+  caption: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.md,
+    lineHeight: 18,
+  },
+  label: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.sm,
+    letterSpacing: 0.5,
+  },
+  // Mailchimp-style uppercase tag.
+  labelCaps: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.sm,
+    letterSpacing: 1.4,
+    textTransform: "uppercase" as const,
+  },
   mono: {
     fontFamily: fontFamily.mono,
     fontSize: fontSize.lg,
@@ -334,7 +398,6 @@ export const leadStatusPalette: Record<LeadStatusKey, StatusPaletteEntry> = {
   },
 };
 
-// Priority palette: mapeia api Lead.priority. Critical chama atencao maxima.
 export type LeadPriorityKey = "low" | "medium" | "high" | "critical";
 
 export const leadPriorityPalette: Record<LeadPriorityKey, StatusPaletteEntry> = {
@@ -352,19 +415,18 @@ export const leadPriorityPalette: Record<LeadPriorityKey, StatusPaletteEntry> = 
   },
   high: {
     labelKey: "priority.high",
-    color: FORD_BLUE_DARK_MODE,
+    color: "#5B8DEF",
     bg: "rgba(91, 141, 239, 0.16)",
     border: "rgba(91, 141, 239, 0.45)",
   },
   critical: {
     labelKey: "priority.critical",
-    color: "#FF5463",
-    bg: "rgba(255, 84, 99, 0.16)",
-    border: "rgba(255, 84, 99, 0.50)",
+    color: "#FF453A",
+    bg: "rgba(255, 69, 58, 0.16)",
+    border: "rgba(255, 69, 58, 0.50)",
   },
 };
 
-// Churn segment palette: mapeia segment do ChurnScore.
 export type ChurnSegmentKey = "fiel" | "abandono" | "esquecido" | "economico";
 
 export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = {
@@ -376,9 +438,9 @@ export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = 
   },
   abandono: {
     labelKey: "segment.abandono",
-    color: "#FF5463",
-    bg: "rgba(255, 84, 99, 0.14)",
-    border: "rgba(255, 84, 99, 0.40)",
+    color: "#FF453A",
+    bg: "rgba(255, 69, 58, 0.14)",
+    border: "rgba(255, 69, 58, 0.40)",
   },
   esquecido: {
     labelKey: "segment.esquecido",
@@ -394,9 +456,9 @@ export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = 
   },
 };
 
-// Tokens legados — mantidos para callers ainda nao migrados. Vao sumir
-// conforme as telas adotam useTheme(). NAO usar em codigo novo.
-// Legacy tokens: nao usar em codigo novo. Migrar para useTheme().
+// Legacy color export — kept so any code path still importing from this module
+// instead of useTheme() does not break. Migrate consumers to useTheme().
+// Tokens legados: nao usar em codigo novo. Migrar para useTheme().
 export const colors = palette.dark;
 export type ColorToken = keyof ThemeColors;
 export type SpacingToken = keyof typeof spacing;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,18 @@
       "name": "forward-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@expo-google-fonts/fraunces": "^0.4.1",
+        "@expo-google-fonts/inter": "^0.4.2",
         "@expo/metro-runtime": "~55.0.9",
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@supabase/supabase-js": "^2.45.0",
         "expo": "^55.0.15",
+        "expo-blur": "~55.0.14",
         "expo-constants": "~55.0.14",
         "expo-haptics": "~55.0.14",
         "expo-image-picker": "~55.0.20",
+        "expo-linear-gradient": "~55.0.14",
         "expo-linking": "~55.0.13",
         "expo-router": "~55.0.12",
         "expo-secure-store": "~55.0.13",
@@ -1424,6 +1428,18 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/@expo-google-fonts/fraunces": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/fraunces/-/fraunces-0.4.1.tgz",
+      "integrity": "sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/inter": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.4.2.tgz",
+      "integrity": "sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/material-symbols": {
       "version": "0.4.31",
@@ -4458,6 +4474,17 @@
         }
       }
     },
+    "node_modules/expo-blur": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-55.0.14.tgz",
+      "integrity": "sha512-NKyCKFWTNpX4CZSsiE1sgkqk/yvR1K0UTukuIbxVKoobB+yALLg1CFav0NqfdQqjhtoj5oEzP0Brlq92Z08Zfg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "55.0.14",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.14.tgz",
@@ -4545,6 +4572,17 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-55.0.14.tgz",
+      "integrity": "sha512-n01A9P0ZebRo8Rm4QHYEjMR8z4Y6MBc8uVnT8NB9cOJislvEmz2o2WQJoK6RD7FjoeFEW8KkRtggK7fQ3h7KIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@expo-google-fonts/fraunces": "^0.4.1",
+    "@expo-google-fonts/inter": "^0.4.2",
     "@expo/metro-runtime": "~55.0.9",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@supabase/supabase-js": "^2.45.0",
     "expo": "^55.0.15",
+    "expo-blur": "~55.0.14",
     "expo-constants": "~55.0.14",
     "expo-haptics": "~55.0.14",
     "expo-image-picker": "~55.0.20",
+    "expo-linear-gradient": "~55.0.14",
     "expo-linking": "~55.0.13",
     "expo-router": "~55.0.12",
     "expo-secure-store": "~55.0.13",


### PR DESCRIPTION
## Summary

Tela **Home** + componente **LeadCard** migrados. Stacked sobre [#35 (Login)](https://github.com/fwd-ford/forward-mobile/pull/35).

### LeadCard
- \`Card\` -> \`GlassSurface variant=\"thin\"\` (cards sentam sobre o mesh, ganham textura)
- Cor do \`value\` (R\$ X) trocou de \`c.primary\` (que agora e branco) pra \`c.text\` (legivel em ambos modos)
- Layout intacto: stripe + chip + VIN mono + razao + status dot + valor

### Home
- Container transparente
- ScreenHeader saiu — header inline com padrao Mailchimp:
  - \`labelCaps\` \"HOJE\" pequeno + Fraunces 40 com greeting
- Hero KPI agora em \`GlassSurface variant=\"regular\"\` radius 24, divider hairline
- Hero value: 32px Inter SemiBold tabular (era 28px mono — lia como codigo, não stat)
- Section title \"Leads de hoje\" em Fraunces 28 (\`hSection\`)
- Lead items ganharam margin horizontal individual (glass card respira)
- Estado de erro tem pill retry CTA usando o novo token \`primary\` theme-aware
- Zero referência ao Ford Blue nesta tela

## Test plan

- [x] \`npx tsc --noEmit\` zero erros
- [ ] Manual: Home renderiza com mesh atras, greeting Fraunces grande, hero glass
- [ ] Manual: LeadCard com glass + stripe + chip ainda legivel
- [ ] Manual: trocar tema light/dark — hero card adapta o glass
- [ ] Manual: estado de erro mostra pill retry branco/preto

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>