### PR TITLE
feat(design): Tab bar Glass floating [Fase 2, 6/6]

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     "userInterfaceStyle": "automatic",
     "splash": {
       "resizeMode": "contain",
-      "backgroundColor": "#0B1220"
+      "backgroundColor": "#1E1E1E"
     },
     "assetBundlePatterns": [
       "**/*"
@@ -20,7 +20,7 @@
     "android": {
       "package": "com.fwdford.forwardservice",
       "adaptiveIcon": {
-        "backgroundColor": "#0B1220"
+        "backgroundColor": "#1E1E1E"
       }
     },
     "web": {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -56,6 +56,10 @@ export default function TabsLayout() {
         // default; without this the mesh background gets covered inside tabs.
         // sceneStyle no v7 substituiu sceneContainerStyle do v6.
         sceneStyle: { backgroundColor: "transparent" },
+        // animation 'none' avoids the visible overlap when both scenes are
+        // transparent and the cross-fade momentarily renders both stacked.
+        // Sem isso, a troca de aba mostra ambas as cenas sobrepostas.
+        animation: "none",
         tabBarStyle: {
           position: "absolute",
           left: 0,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -52,6 +52,10 @@ export default function TabsLayout() {
     <Tabs
       screenOptions={{
         headerShown: false,
+        // react-navigation/bottom-tabs v7 paints the scene container white by
+        // default; without this the mesh background gets covered inside tabs.
+        // sceneStyle no v7 substituiu sceneContainerStyle do v6.
+        sceneStyle: { backgroundColor: "transparent" },
         tabBarStyle: {
           position: "absolute",
           left: 0,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,10 +1,19 @@
+// Tab bar — Glass Minimalist redesign (Fase 2, screen 6/6).
+// Bar is absolute-positioned and uses GlassSurface variant="thick" as the
+// background; expo-router renders the labels/icons on top. Active tint moves
+// from primary (was Ford Blue) to text token so it reads in both modes.
+//
+// Tab bar glass thick flutuando sobre conteudo (estilo iOS).
+
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
 import { useCallback } from "react";
 import { StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
 
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { useTheme } from "@/context/ThemeContext";
+import { fontFamily } from "@/lib/theme";
 
 type TabIconKey = "index" | "leads" | "profile";
 
@@ -32,7 +41,7 @@ export default function TabsLayout() {
       ({ color, size, focused }: TabIconRenderProps) => (
         <Ionicons
           name={focused ? ICONS[key].focused : ICONS[key].unfocused}
-          size={size}
+          size={size - 2}
           color={color}
         />
       ),
@@ -44,13 +53,37 @@ export default function TabsLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: {
-          backgroundColor: colors.tabBar,
-          borderTopColor: colors.separator,
-          borderTopWidth: StyleSheet.hairlineWidth,
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: "transparent",
+          borderTopWidth: 0,
+          elevation: 0,
         },
-        tabBarActiveTintColor: colors.primary,
+        // Hairline divider on top so the glass tab bar reads as detached, not
+        // floating ambiguously over content. tabBarBackground owns the blur.
+        tabBarBackground: () => (
+          <GlassSurface
+            variant="thick"
+            radius={0}
+            border={false}
+            style={[
+              StyleSheet.absoluteFillObject,
+              {
+                borderTopWidth: StyleSheet.hairlineWidth,
+                borderTopColor: colors.glassBorder,
+              },
+            ]}
+          />
+        ),
+        tabBarActiveTintColor: colors.text,
         tabBarInactiveTintColor: colors.textMuted,
-        tabBarLabelStyle: { fontSize: 12, fontWeight: "600" },
+        tabBarLabelStyle: {
+          fontFamily: fontFamily.semibold,
+          fontSize: 11,
+          letterSpacing: 0.2,
+        },
       }}
     >
       <Tabs.Screen

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,3 +1,13 @@
+// Home — Glass Minimalist redesign (Fase 2, screen 2/6).
+// Layout:
+//   label-caps "HOJE" -> Fraunces 40 greeting
+//   GlassSurface hero with 2 KPI columns (active leads + pipeline)
+//   "Leads recentes" Fraunces 28 section header
+//   Lista de LeadCards (LeadCard ja foi migrado pra GlassSurface thin)
+//
+// Header inline per the screen-by-screen workflow; ScreenTitle vira component
+// na Fase 3 quando todas as telas tiverem o mesmo padrao.
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FlatList,
@@ -12,18 +22,16 @@ import { useTranslation } from "react-i18next";
 
 import { LeadCard } from "@/components/domain/LeadCard";
 import { LeadCardSkeleton } from "@/components/domain/LeadCardSkeleton";
-import { Button } from "@/components/ui/Button";
-import { Card } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
-import { ScreenHeader } from "@/components/ui/ScreenHeader";
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { useTheme } from "@/context/ThemeContext";
 import { ACTIVE_LEAD_STATUSES, api, ApiError, type Lead } from "@/lib/api";
 import { formatBRL } from "@/lib/format";
 import { fetchMyProfile } from "@/lib/profile";
 import { getAccessToken } from "@/lib/session";
 import { supabase } from "@/lib/supabase";
-import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { fontFamily, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
 type HeroStats = {
   activeLeads: number;
@@ -32,9 +40,8 @@ type HeroStats = {
 
 const TOP_VISIBLE = 5;
 // Hero stats sao calculados client-side a partir do array retornado por listLeads.
-// Sprint 1 nao tem endpoint dedicado de agregacao (/leads/stats), entao puxamos um
-// teto bem acima da expectativa real por vendedor (~50 leads ativos). Quando o backend
-// expor agregacao, trocar isso por uma chamada dedicada e parar de truncar.
+// Sprint 1 nao tem endpoint dedicado de agregacao (/leads/stats), entao puxamos
+// um teto bem acima da expectativa real por vendedor.
 const HERO_FETCH_LIMIT = 200;
 const GREETING_REFRESH_MS = 60_000;
 
@@ -60,8 +67,6 @@ export default function HomeScreen() {
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState<string>("");
-  // Reavalia o greeting periodicamente: sem isso o usuario que abre o app as 11h55
-  // ve "Bom dia" ate fechar e reabrir, mesmo passando do meio-dia.
   const [now, setNow] = useState(() => new Date());
 
   const load = useCallback(async () => {
@@ -113,6 +118,8 @@ export default function HomeScreen() {
   const topLeads = useMemo(() => leads.slice(0, TOP_VISIBLE), [leads]);
   const greeting = t(greetingKey(now.getHours()), { name: name || "" });
 
+  const showHero = !(error && leads.length === 0);
+
   return (
     <FlatList
       style={styles.container}
@@ -120,40 +127,39 @@ export default function HomeScreen() {
       keyExtractor={(l) => l.id}
       contentContainerStyle={styles.list}
       refreshControl={
-        <RefreshControl
-          refreshing={refreshing}
-          onRefresh={onRefresh}
-          tintColor={colors.primary}
-        />
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.text} />
       }
       ListHeaderComponent={
-        <View>
-          <ScreenHeader title={t("home.today")} subtitle={greeting.trim()} />
+        <View style={styles.header}>
+          {/* Label + Fraunces 40 greeting (Mailchimp pattern). */}
+          {/* Label minusculo + titulo Fraunces gigante (padrao Mailchimp). */}
+          <Text style={styles.labelCaps}>{t("home.today")}</Text>
+          <Text style={styles.heroTitle} numberOfLines={2}>
+            {greeting.trim()}
+          </Text>
 
-          {/*
-            Hero hides on initial error with no cached leads: rendering "0 / R$ 0"
-            mid-error reads as real numbers and panics the user. Once any data
-            arrived (e.g. refresh-after-success), keep it visible even if a later
-            refresh errors so stale-but-useful beats blank.
-            Hero some no erro inicial sem leads: "0 / R$ 0" parece dado real e
-            assusta. Com dados em cache, mantem mesmo num erro de refresh.
-          */}
-          {!(error && leads.length === 0) ? (
-            <Card style={styles.hero}>
-              <View style={styles.heroCol}>
-                <Text style={styles.heroLabel}>{t("home.hero.active_leads")}</Text>
-                <Text style={styles.heroValue}>{hero.activeLeads}</Text>
+          {showHero ? (
+            <GlassSurface variant="regular" radius={24} style={styles.heroCard}>
+              <View style={styles.heroInner}>
+                <View style={styles.heroCol}>
+                  <Text style={styles.heroLabel}>{t("home.hero.active_leads")}</Text>
+                  <Text style={styles.heroValue}>{hero.activeLeads}</Text>
+                </View>
+                <View style={styles.heroDivider} />
+                <View style={styles.heroCol}>
+                  <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
+                  <Text style={styles.heroValue}>
+                    {formatBRL(hero.pipelineBRL, { compact: true })}
+                  </Text>
+                </View>
               </View>
-              <View style={styles.heroDivider} />
-              <View style={styles.heroCol}>
-                <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
-                <Text style={styles.heroValue}>{formatBRL(hero.pipelineBRL, { compact: true })}</Text>
-              </View>
-            </Card>
+            </GlassSurface>
           ) : null}
 
           {error && leads.length > 0 ? (
-            <ErrorBanner message={error} onRetry={() => void load()} />
+            <View style={styles.errorWrap}>
+              <ErrorBanner message={error} onRetry={() => void load()} />
+            </View>
           ) : null}
 
           {initialLoading ? (
@@ -162,24 +168,30 @@ export default function HomeScreen() {
               <LeadCardSkeleton />
               <LeadCardSkeleton />
             </View>
+          ) : !initialLoading && topLeads.length > 0 ? (
+            <Text style={styles.sectionTitle}>{t("home.todays_leads")}</Text>
           ) : null}
         </View>
       }
       ListEmptyComponent={
         !initialLoading ? (
           error ? (
-            <EmptyState
-              icon="cloud-offline-outline"
-              title={t("home.error_title")}
-              description={error}
-              action={
-                <Button
-                  label={t("common.retry")}
-                  variant="secondary"
-                  onPress={() => void load()}
-                />
-              }
-            />
+            <View style={styles.emptyWrap}>
+              <EmptyState
+                icon="cloud-offline-outline"
+                title={t("home.error_title")}
+                description={error}
+              />
+              <Pressable
+                onPress={() => void load()}
+                style={({ pressed }) => [
+                  styles.retryPill,
+                  pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
+                ]}
+              >
+                <Text style={styles.retryPillLabel}>{t("common.retry")}</Text>
+              </Pressable>
+            </View>
           ) : (
             <EmptyState
               icon="briefcase-outline"
@@ -203,69 +215,101 @@ export default function HomeScreen() {
         ) : null
       }
       renderItem={({ item }) => (
-        <LeadCard
-          lead={item}
-          onPress={() =>
-            router.push({
-              pathname: "/lead/[id]",
-              // Hidrata o detalhe na hora pra evitar refetch de 200 leads. Veja lead/[id].tsx.
-              params: { id: item.id, lead: JSON.stringify(item) },
-            })
-          }
-        />
+        <View style={styles.leadItem}>
+          <LeadCard
+            lead={item}
+            onPress={() =>
+              router.push({
+                pathname: "/lead/[id]",
+                params: { id: item.id, lead: JSON.stringify(item) },
+              })
+            }
+          />
+        </View>
       )}
-      ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
     />
   );
 }
 
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { backgroundColor: c.bg },
-    list: { paddingBottom: spacing["4xl"] },
-    hero: {
+    container: { backgroundColor: "transparent" },
+    list: { paddingBottom: spacing["6xl"] },
+    header: {
+      paddingHorizontal: spacing["2xl"],
+      paddingTop: spacing["3xl"],
+      gap: spacing.md,
+    },
+    labelCaps: {
+      ...typography.labelCaps,
+      color: c.textMuted,
+    },
+    heroTitle: {
+      ...typography.hDisplay,
+      color: c.text,
+      marginBottom: spacing.lg,
+    },
+    heroCard: {
+      marginBottom: spacing["2xl"],
+    },
+    heroInner: {
       flexDirection: "row",
       alignItems: "stretch",
-      marginHorizontal: spacing.xl,
-      marginBottom: spacing.lg,
-      padding: spacing.lg,
+      padding: spacing.xl,
     },
     heroCol: { flex: 1, gap: spacing.xs },
     heroDivider: {
-      width: 1,
-      backgroundColor: c.separator,
-      marginHorizontal: spacing.md,
+      width: StyleSheet.hairlineWidth,
+      backgroundColor: c.glassBorder,
+      marginHorizontal: spacing.lg,
     },
     heroLabel: {
-      ...typography.label,
+      ...typography.labelCaps,
       color: c.textMuted,
-      textTransform: "uppercase",
     },
     heroValue: {
-      ...typography.mono,
-      fontSize: 28,
+      fontFamily: fontFamily.semibold,
+      fontSize: 32,
+      letterSpacing: -0.6,
       color: c.text,
-      fontWeight: "800",
-      letterSpacing: -0.3,
     },
-    skeletonStack: {
-      gap: spacing.md,
-      paddingHorizontal: spacing.xl,
+    errorWrap: { marginBottom: spacing.lg },
+    skeletonStack: { gap: spacing.md, marginTop: spacing.sm },
+    sectionTitle: {
+      ...typography.hSection,
+      color: c.text,
+      marginTop: spacing.sm,
+      marginBottom: spacing.xs,
+    },
+    leadItem: {
+      marginHorizontal: spacing["2xl"],
+      marginTop: spacing.md,
+    },
+    emptyWrap: { alignItems: "center", marginTop: spacing["2xl"], gap: spacing.lg },
+    retryPill: {
+      paddingVertical: spacing.md - 2,
+      paddingHorizontal: spacing["2xl"],
+      borderRadius: radius.pill,
+      backgroundColor: c.primary,
+    },
+    retryPillLabel: {
+      ...typography.body,
+      fontFamily: fontFamily.semibold,
+      color: c.primaryText,
     },
     seeAll: {
-      marginTop: spacing.lg,
-      marginHorizontal: spacing.xl,
+      marginTop: spacing.xl,
+      marginHorizontal: spacing["2xl"],
       paddingVertical: spacing.md,
-      borderRadius: radius.md,
-      borderWidth: 1,
-      borderColor: c.border,
-      backgroundColor: c.surface,
+      borderRadius: radius.pill,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: c.borderStrong,
       alignItems: "center",
     },
     seeAllLabel: {
       ...typography.caption,
-      fontWeight: "700",
-      color: c.primary,
+      fontFamily: fontFamily.semibold,
+      color: c.text,
     },
   });
 }

--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -1,3 +1,8 @@
+// Leads — Glass Minimalist redesign (Fase 2, screen 3/6).
+// Header: labelCaps with count + Fraunces 40 "Leads" title.
+// Inline glass search bar + filter chips (active=solid pill, inactive=glass).
+// LeadCard list already migrated to GlassSurface in the Home PR.
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FlatList,
@@ -6,8 +11,10 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
@@ -15,13 +22,12 @@ import { LeadCard } from "@/components/domain/LeadCard";
 import { LeadCardSkeleton } from "@/components/domain/LeadCardSkeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
-import { Input } from "@/components/ui/Input";
-import { ScreenHeader } from "@/components/ui/ScreenHeader";
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { useTheme } from "@/context/ThemeContext";
 import { haptic } from "@/lib/haptics";
 import { ACTIVE_LEAD_STATUSES, api, ApiError, type Lead } from "@/lib/api";
 import { getAccessToken } from "@/lib/session";
-import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { fontFamily, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
 type FilterKey = "all" | "critical" | "today" | "forgotten";
 
@@ -51,7 +57,6 @@ function applyFilters(leads: Lead[], filter: FilterKey, query: string): Lead[] {
       out = out.filter((l) => l.priority === "critical");
       break;
     case "today": {
-      // Hoje = a partir do inicio do dia local, nao "ultimas 24h".
       const cutoff = startOfTodayMs();
       out = out.filter((l) => {
         const t = parseTimestamp(l.created_at);
@@ -60,9 +65,7 @@ function applyFilters(leads: Lead[], filter: FilterKey, query: string): Lead[] {
       break;
     }
     case "forgotten": {
-      // Proxy para "sem follow-up ha >=30d": status ainda nao avancou
-      // (new/assigned) e created_at >=30d atras. Quando o backend expor
-      // last_contact_at, trocar pra esse campo.
+      // Proxy para "sem follow-up ha >=30d": status ainda nao avancou e created_at >=30d.
       const cutoff = Date.now() - 30 * DAY_MS;
       out = out.filter((l) => {
         if (l.status === "contacted" || l.status === "converted") return false;
@@ -99,6 +102,7 @@ export default function LeadsScreen() {
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
 
   const load = useCallback(async () => {
     setError(null);
@@ -135,58 +139,93 @@ export default function LeadsScreen() {
     setFilter(k);
   }
 
+  const filters: { key: FilterKey; labelKey: string }[] = [
+    { key: "all", labelKey: "leads.filter.all" },
+    { key: "critical", labelKey: "leads.filter.critical" },
+    { key: "today", labelKey: "leads.filter.today" },
+    { key: "forgotten", labelKey: "leads.filter.forgotten" },
+  ];
+
+  const subtitle = isFiltering
+    ? t("leads.subtitle_showing", { showing: filtered.length, total: activeCount })
+    : activeCount === 0
+      ? t("leads.subtitle_count_zero")
+      : t("leads.subtitle_count", { count: activeCount });
+
   return (
     <View style={styles.container}>
-      <ScreenHeader
-        title={t("leads.title")}
-        subtitle={
-          isFiltering
-            ? t("leads.subtitle_showing", { showing: filtered.length, total: activeCount })
-            : activeCount === 0
-              ? t("leads.subtitle_count_zero")
-              : t("leads.subtitle_count", { count: activeCount })
-        }
-      />
+      <View style={styles.header}>
+        <Text style={styles.labelCaps}>{subtitle}</Text>
+        <Text style={styles.heroTitle} numberOfLines={1}>
+          {t("leads.title")}
+        </Text>
 
-      <View style={styles.controls}>
-        <Input
-          value={query}
-          onChangeText={setQuery}
-          placeholder={t("leads.search_placeholder")}
-          icon="search-outline"
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
+        {/* Glass pill search */}
+        <GlassSurface variant="thin" radius={radius.pill} style={styles.searchWrap}>
+          <View style={styles.searchInner}>
+            <Ionicons name="search-outline" size={18} color={colors.textMuted} />
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder={t("leads.search_placeholder")}
+              placeholderTextColor={colors.textSubtle}
+              autoCapitalize="none"
+              autoCorrect={false}
+              onFocus={() => setSearchFocused(true)}
+              onBlur={() => setSearchFocused(false)}
+              style={[styles.searchInput, { color: colors.text }]}
+            />
+            {query.length > 0 ? (
+              <Pressable onPress={() => setQuery("")} hitSlop={8}>
+                <Ionicons name="close-circle" size={16} color={colors.textSubtle} />
+              </Pressable>
+            ) : null}
+          </View>
+        </GlassSurface>
+
+        {/* Glass / solid pill chips */}
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
-          contentContainerStyle={styles.chips}
+          contentContainerStyle={styles.chipsRow}
         >
-          {(["all", "critical", "today", "forgotten"] as FilterKey[]).map((k) => {
-            const active = filter === k;
+          {filters.map((f) => {
+            const active = filter === f.key;
+            const Wrapper = active ? View : GlassSurface;
             return (
               <Pressable
-                key={k}
-                onPress={() => onFilterPress(k)}
-                style={({ pressed }) => [
-                  styles.chip,
-                  active && styles.chipActive,
-                  pressed && { opacity: 0.8 },
-                ]}
+                key={f.key}
+                onPress={() => onFilterPress(f.key)}
                 accessibilityRole="button"
                 accessibilityState={{ selected: active }}
+                style={({ pressed }) => [pressed && { opacity: 0.85 }]}
               >
-                <Text style={[styles.chipLabel, active && styles.chipLabelActive]}>
-                  {t(`leads.filter.${k}`)}
-                </Text>
+                <Wrapper
+                  variant="thin"
+                  radius={radius.pill}
+                  style={[styles.chip, active && styles.chipActive]}
+                >
+                  <Text
+                    style={[
+                      styles.chipLabel,
+                      { color: active ? colors.primaryText : colors.text },
+                    ]}
+                  >
+                    {t(f.labelKey)}
+                  </Text>
+                </Wrapper>
               </Pressable>
             );
           })}
         </ScrollView>
       </View>
 
-      {error ? <ErrorBanner message={error} onRetry={() => void load()} /> : null}
+      {error ? (
+        <View style={styles.errorWrap}>
+          <ErrorBanner message={error} onRetry={() => void load()} />
+        </View>
+      ) : null}
 
       {initialLoading ? (
         <View style={styles.skeletonStack}>
@@ -204,7 +243,7 @@ export default function LeadsScreen() {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={onRefresh}
-              tintColor={colors.primary}
+              tintColor={colors.text}
             />
           }
           ListEmptyComponent={
@@ -225,18 +264,18 @@ export default function LeadsScreen() {
             ) : null
           }
           renderItem={({ item }) => (
-            <LeadCard
-              lead={item}
-              onPress={() =>
-                router.push({
-                  pathname: "/lead/[id]",
-                  // Hidrata o detalhe na hora pra evitar refetch de 200 leads. Veja lead/[id].tsx.
-                  params: { id: item.id, lead: JSON.stringify(item) },
-                })
-              }
-            />
+            <View style={styles.leadItem}>
+              <LeadCard
+                lead={item}
+                onPress={() =>
+                  router.push({
+                    pathname: "/lead/[id]",
+                    params: { id: item.id, lead: JSON.stringify(item) },
+                  })
+                }
+              />
+            </View>
           )}
-          ItemSeparatorComponent={() => <View style={{ height: spacing.md }} />}
         />
       )}
     </View>
@@ -245,43 +284,67 @@ export default function LeadsScreen() {
 
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { flex: 1, backgroundColor: c.bg },
-    controls: {
-      paddingHorizontal: spacing.xl,
+    container: { flex: 1, backgroundColor: "transparent" },
+    header: {
+      paddingHorizontal: spacing["2xl"],
+      paddingTop: spacing["3xl"],
       gap: spacing.md,
+    },
+    labelCaps: {
+      ...typography.labelCaps,
+      color: c.textMuted,
+    },
+    heroTitle: {
+      ...typography.hDisplay,
+      color: c.text,
       marginBottom: spacing.md,
     },
-    chips: {
+    searchWrap: { marginBottom: spacing.xs },
+    searchInner: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.sm,
+      paddingHorizontal: spacing.lg,
+      height: 48,
+    },
+    searchInput: {
+      flex: 1,
+      ...typography.body,
+      paddingVertical: 0,
+    },
+    chipsRow: {
       gap: spacing.sm,
       paddingVertical: spacing.xs,
+      paddingRight: spacing["2xl"],
     },
     chip: {
-      paddingHorizontal: spacing.md,
-      paddingVertical: spacing.xs + 2,
-      borderRadius: radius.pill,
-      backgroundColor: c.surface,
-      borderWidth: 1,
-      borderColor: c.border,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.sm + 2,
     },
     chipActive: {
       backgroundColor: c.primary,
-      borderColor: c.primary,
+      borderWidth: 0,
     },
     chipLabel: {
       ...typography.caption,
-      fontWeight: "600",
-      color: c.text,
+      fontFamily: fontFamily.semibold,
     },
-    chipLabelActive: {
-      color: c.primaryText,
+    errorWrap: {
+      paddingHorizontal: spacing["2xl"],
+      marginBottom: spacing.md,
     },
     skeletonStack: {
       gap: spacing.md,
-      paddingHorizontal: spacing.xl,
+      paddingHorizontal: spacing["2xl"],
+      marginTop: spacing.md,
     },
     list: {
-      padding: spacing.xl,
-      paddingBottom: spacing["4xl"],
+      paddingTop: spacing.md,
+      paddingBottom: spacing["6xl"],
+    },
+    leadItem: {
+      marginHorizontal: spacing["2xl"],
+      marginBottom: spacing.md,
     },
   });
 }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,3 +1,9 @@
+// Profile — Glass Minimalist redesign (Fase 2, screen 4/6).
+// Header: labelCaps "CONTA" + Fraunces 40 user name.
+// Avatar 80 + 3 photo buttons (no card wrapper around them).
+// Sections: each is a GlassSurface group containing SettingRows separated
+// by hairline dividers. Sign-out is a ghost pill at the bottom.
+
 import { Ionicons } from "@expo/vector-icons";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -14,12 +20,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { router } from "expo-router";
 
-import { Button } from "@/components/ui/Button";
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { LoadingScreen } from "@/components/ui/LoadingScreen";
 import { LocalePicker } from "@/components/ui/LocalePicker";
 import { PhotoButton } from "@/components/ui/PhotoButton";
 import { ProfileAvatar } from "@/components/ui/ProfileAvatar";
-import { ScreenHeader } from "@/components/ui/ScreenHeader";
 import { SettingRow } from "@/components/ui/SettingRow";
 import { Toast, type ToastVariant } from "@/components/ui/Toast";
 import { useLocale } from "@/context/LocaleContext";
@@ -31,7 +36,7 @@ import { pickFromCamera, pickFromLibrary, type PickedImage } from "@/lib/image-p
 import { LOCALE_LABEL, LOCALE_SHORT } from "@/lib/locale";
 import { fetchMyProfile, updateMyProfile, type Profile } from "@/lib/profile";
 import { supabase } from "@/lib/supabase";
-import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { fontFamily, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
 type ProfileState = {
   email: string | null;
@@ -137,9 +142,6 @@ export default function ProfileScreen() {
 
   const { email, profile } = state;
   const displayName = profile?.full_name ?? t("profile.unnamed");
-  // Sem full_name passamos string vazia para a placeholder mostrar "?" (icone
-  // generico de iniciais), evitando o "JO" estranho derivado de "joao.silva@...".
-  // Quando o onboarding obrigar full_name, esse fallback fica obsoleto.
   const avatarSource = profile?.full_name ?? "";
 
   return (
@@ -147,41 +149,37 @@ export default function ProfileScreen() {
       <ScrollView
         contentContainerStyle={[
           styles.scrollContent,
-          { paddingBottom: insets.bottom + spacing["4xl"] },
+          { paddingBottom: insets.bottom + spacing["6xl"] },
         ]}
         showsVerticalScrollIndicator={false}
       >
-        <ScreenHeader title={t("tabs.profile")} />
+        {/* Header: labelCaps "CONTA" + Fraunces 40 nome */}
+        <View style={styles.header}>
+          <Text style={styles.labelCaps}>{t("profile.account")}</Text>
+          <Text style={styles.heroTitle} numberOfLines={2}>
+            {displayName}
+          </Text>
+          {email ? <Text style={styles.email}>{email}</Text> : null}
+        </View>
 
-        {/* User card: avatar + name + email + photo actions all in one block */}
-        {/* Card do usuario: avatar + identidade + acoes de foto numa secao so */}
-        <View style={styles.userCard}>
-          <View style={styles.userTop}>
-            <Pressable
-              onPress={onPickFromLibrary}
-              disabled={uploadingPhoto}
-              style={({ pressed }) => [styles.avatarPressable, pressed && styles.pressedSoft]}
-              accessibilityRole="button"
-              accessibilityLabel={t("profile.change_photo")}
-            >
-              <ProfileAvatar uri={profile?.avatar_url} source={avatarSource} size={64} />
-              <View style={styles.avatarBadge}>
-                {uploadingPhoto ? (
-                  <ActivityIndicator size="small" color={colors.primaryText} />
-                ) : (
-                  <Ionicons name="camera" size={12} color={colors.primaryText} />
-                )}
-              </View>
-            </Pressable>
-            <View style={styles.userInfo}>
-              <Text style={styles.userName} numberOfLines={1}>
-                {displayName}
-              </Text>
-              <Text style={styles.userEmail} numberOfLines={1}>
-                {email ?? "—"}
-              </Text>
+        {/* Avatar inline (no card wrapper) + 3 photo buttons in a row */}
+        <View style={styles.avatarBlock}>
+          <Pressable
+            onPress={onPickFromLibrary}
+            disabled={uploadingPhoto}
+            style={({ pressed }) => [styles.avatarPressable, pressed && styles.pressedSoft]}
+            accessibilityRole="button"
+            accessibilityLabel={t("profile.change_photo")}
+          >
+            <ProfileAvatar uri={profile?.avatar_url} source={avatarSource} size={88} />
+            <View style={styles.avatarBadge}>
+              {uploadingPhoto ? (
+                <ActivityIndicator size="small" color={colors.primaryText} />
+              ) : (
+                <Ionicons name="camera" size={14} color={colors.primaryText} />
+              )}
             </View>
-          </View>
+          </Pressable>
 
           <View style={styles.photoButtonsRow}>
             <PhotoButton
@@ -208,69 +206,72 @@ export default function ProfileScreen() {
           </View>
         </View>
 
-        <Text style={styles.sectionTitle}>{t("profile.appearance")}</Text>
-
-        <SettingRow
-          icon={mode === "dark" ? "moon" : "sunny"}
-          // Label always describes what the switch CONTROLS ("Dark mode"); the
-          // value line tells you the current setting. Previously the label
-          // mirrored the current mode and reading "Modo claro" + switch OFF
-          // sounded like "turning off light mode" — accidental coincidence.
-          // Label sempre descreve o que o switch controla; value mostra o estado.
-          label={t("profile.dark_mode")}
-          value={isOverridden ? t("profile.theme_manual") : t("profile.theme_auto")}
-          emphasis="label"
-          right={
-            <Switch
-              value={mode === "dark"}
-              onValueChange={onToggleTheme}
-              trackColor={{ false: colors.borderStrong, true: colors.primary }}
-              thumbColor="#FFFFFF"
-              ios_backgroundColor={colors.borderStrong}
-              // react-native-web ignores trackColor on the rendered <input type="checkbox">.
-              // accentColor is the native CSS property browsers honor for form-control tint.
-              // No web o trackColor nao se aplica; accentColor e o property CSS que pinta.
-              style={
-                Platform.OS === "web"
-                  ? ({ accentColor: colors.primary } as never)
-                  : undefined
-              }
-            />
-          }
-        />
-
-        {isOverridden ? (
-          <Pressable
-            onPress={onResetToSystem}
-            style={({ pressed }) => [styles.linkRow, pressed && styles.pressedSoft]}
-            accessibilityRole="button"
-            accessibilityLabel={t("profile.follow_system")}
-          >
-            <Text style={styles.linkText}>{t("profile.follow_system")}</Text>
-          </Pressable>
-        ) : null}
-
-        <Text style={styles.sectionTitle}>{t("profile.language")}</Text>
-
-        <Pressable
-          onPress={onOpenLocalePicker}
-          style={({ pressed }) => [pressed && styles.pressedSoft]}
-          accessibilityRole="button"
-          accessibilityLabel={`${t("profile.language")}: ${LOCALE_LABEL[locale]}`}
-        >
+        {/* Aparencia section — glass group, rows separadas por hairline */}
+        <Text style={styles.sectionLabel}>{t("profile.appearance")}</Text>
+        <GlassSurface variant="thin" radius={20} style={styles.sectionGroup}>
           <SettingRow
-            icon="globe-outline"
-            label={t("profile.language")}
-            value={`${LOCALE_LABEL[locale]} · ${LOCALE_SHORT[locale]}`}
-            right={<Ionicons name="chevron-down" size={16} color={colors.textSubtle} />}
+            icon={mode === "dark" ? "moon" : "sunny"}
+            label={t("profile.dark_mode")}
+            value={isOverridden ? t("profile.theme_manual") : t("profile.theme_auto")}
+            emphasis="label"
+            divider={isOverridden}
+            right={
+              <Switch
+                value={mode === "dark"}
+                onValueChange={onToggleTheme}
+                trackColor={{ false: colors.borderStrong, true: colors.primary }}
+                thumbColor={mode === "dark" ? colors.primaryText : "#FFFFFF"}
+                ios_backgroundColor={colors.borderStrong}
+                style={
+                  Platform.OS === "web"
+                    ? ({ accentColor: colors.primary } as never)
+                    : undefined
+                }
+              />
+            }
           />
+          {isOverridden ? (
+            <Pressable
+              onPress={onResetToSystem}
+              style={({ pressed }) => [styles.linkRow, pressed && styles.pressedSoft]}
+              accessibilityRole="button"
+              accessibilityLabel={t("profile.follow_system")}
+            >
+              <Text style={styles.linkText}>{t("profile.follow_system")}</Text>
+            </Pressable>
+          ) : null}
+        </GlassSurface>
+
+        {/* Idioma */}
+        <Text style={styles.sectionLabel}>{t("profile.language")}</Text>
+        <GlassSurface variant="thin" radius={20} style={styles.sectionGroup}>
+          <Pressable
+            onPress={onOpenLocalePicker}
+            style={({ pressed }) => [pressed && styles.pressedSoft]}
+            accessibilityRole="button"
+            accessibilityLabel={`${t("profile.language")}: ${LOCALE_LABEL[locale]}`}
+          >
+            <SettingRow
+              icon="globe-outline"
+              label={t("profile.language")}
+              value={`${LOCALE_LABEL[locale]} · ${LOCALE_SHORT[locale]}`}
+              right={<Ionicons name="chevron-down" size={16} color={colors.textSubtle} />}
+            />
+          </Pressable>
+        </GlassSurface>
+
+        {/* Sign out — ghost pill, no section title needed (label already in header) */}
+        <Pressable
+          onPress={onSignOut}
+          accessibilityRole="button"
+          accessibilityLabel={t("profile.sign_out")}
+          style={({ pressed }) => [
+            styles.signOutPill,
+            pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
+          ]}
+        >
+          <Text style={styles.signOutLabel}>{t("profile.sign_out")}</Text>
         </Pressable>
-
-        <Text style={styles.sectionTitle}>{t("profile.account")}</Text>
-
-        <View style={styles.actionsCard}>
-          <Button label={t("profile.sign_out")} variant="ghost" onPress={onSignOut} />
-        </View>
       </ScrollView>
 
       <Toast
@@ -287,76 +288,86 @@ export default function ProfileScreen() {
 
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { flex: 1, backgroundColor: c.bg },
+    container: { flex: 1, backgroundColor: "transparent" },
     scrollContent: { paddingHorizontal: 0 },
-    userCard: {
-      marginHorizontal: spacing.xl,
-      marginBottom: spacing.xl,
-      backgroundColor: c.surface,
-      borderRadius: radius.xl,
-      padding: spacing.lg,
-      borderWidth: 1,
-      borderColor: c.border,
-      gap: spacing.lg,
+    header: {
+      paddingHorizontal: spacing["2xl"],
+      paddingTop: spacing["3xl"],
+      gap: spacing.sm,
     },
-    userTop: {
-      flexDirection: "row",
+    labelCaps: {
+      ...typography.labelCaps,
+      color: c.textMuted,
+    },
+    heroTitle: {
+      ...typography.hDisplay,
+      color: c.text,
+    },
+    email: {
+      ...typography.body,
+      color: c.textMuted,
+    },
+    avatarBlock: {
       alignItems: "center",
       gap: spacing.lg,
+      paddingVertical: spacing["2xl"],
+      paddingHorizontal: spacing["2xl"],
     },
     avatarPressable: { position: "relative" },
     avatarBadge: {
       position: "absolute",
-      bottom: -2,
-      right: -2,
-      width: 22,
-      height: 22,
-      borderRadius: 11,
+      bottom: 2,
+      right: 2,
+      width: 26,
+      height: 26,
+      borderRadius: 13,
       backgroundColor: c.primary,
       alignItems: "center",
       justifyContent: "center",
       borderWidth: 2,
-      borderColor: c.surface,
-    },
-    userInfo: { flex: 1 },
-    userName: {
-      ...typography.h3,
-      color: c.text,
-    },
-    userEmail: {
-      ...typography.caption,
-      color: c.textMuted,
-      marginTop: 2,
+      borderColor: c.bg,
     },
     photoButtonsRow: {
       flexDirection: "row",
       flexWrap: "wrap",
       gap: spacing.sm,
+      justifyContent: "center",
     },
-    sectionTitle: {
-      ...typography.label,
+    sectionLabel: {
+      ...typography.labelCaps,
       color: c.textMuted,
-      textTransform: "uppercase",
-      paddingHorizontal: spacing.xl,
+      paddingHorizontal: spacing["2xl"],
+      marginTop: spacing.lg,
       marginBottom: spacing.sm,
-      marginTop: spacing.sm,
+    },
+    sectionGroup: {
+      marginHorizontal: spacing["2xl"],
+      overflow: "hidden",
     },
     linkRow: {
-      paddingHorizontal: spacing.xl,
-      paddingVertical: spacing.sm,
-      marginBottom: spacing.lg,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.md,
     },
     linkText: {
       ...typography.caption,
-      color: c.primary,
-      fontWeight: "600",
+      fontFamily: fontFamily.semibold,
+      color: c.text,
     },
-    actionsCard: {
-      marginHorizontal: spacing.xl,
-      marginBottom: spacing.xl,
+    signOutPill: {
+      marginTop: spacing["2xl"],
+      marginHorizontal: spacing["2xl"],
+      height: 52,
+      borderRadius: radius.pill,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: c.borderStrong,
+      alignItems: "center",
+      justifyContent: "center",
     },
-    pressedSoft: {
-      opacity: 0.7,
+    signOutLabel: {
+      ...typography.body,
+      fontFamily: fontFamily.semibold,
+      color: c.text,
     },
+    pressedSoft: { opacity: 0.7 },
   });
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,25 @@
 import { Ionicons } from "@expo/vector-icons";
+import {
+  Fraunces_400Regular,
+  Fraunces_600SemiBold,
+  Fraunces_700Bold,
+} from "@expo-google-fonts/fraunces";
+import {
+  Inter_400Regular,
+  Inter_500Medium,
+  Inter_600SemiBold,
+  Inter_700Bold,
+} from "@expo-google-fonts/inter";
 import { useFonts } from "expo-font";
 import { Stack, useRouter, useSegments } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { StyleSheet, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useEffect, useState } from "react";
 
 import "@/i18n";
 import { IntroVideo } from "@/components/ui/IntroVideo";
+import { MeshBackground } from "@/components/ui/MeshBackground";
 import { LocaleProvider } from "@/context/LocaleContext";
 import { ThemeProvider, useTheme } from "@/context/ThemeContext";
 import { supabase } from "@/lib/supabase";
@@ -29,9 +42,20 @@ function RootStack() {
   const [introDone, setIntroDone] = useState(false);
   const [ready, setReady] = useState(false);
   const [session, setSession] = useState<Session | null>(null);
-  // Preload Ionicons so the first paint never shows empty glyph squares (FOIT).
-  // Pre-carrega Ionicons; sem isso, primeiro paint mostra quadrados vazios.
-  const [fontsLoaded] = useFonts(Ionicons.font);
+  // Preload Ionicons + Fraunces (display serif) + Inter (UI sans) so first
+  // paint never shows fallback fonts or empty glyph squares (FOIT).
+  // Pre-carrega Ionicons + Fraunces + Inter; sem isso, primeiro paint usa
+  // fonte de sistema e estraga a hierarquia tipografica.
+  const [fontsLoaded] = useFonts({
+    ...Ionicons.font,
+    Fraunces_400Regular,
+    Fraunces_600SemiBold,
+    Fraunces_700Bold,
+    Inter_400Regular,
+    Inter_500Medium,
+    Inter_600SemiBold,
+    Inter_700Bold,
+  });
 
   // Auth check runs in parallel with the intro — whichever finishes later unblocks the router.
   // Verificacao de sessao roda em paralelo com a intro — o mais lento destrava o router.
@@ -47,16 +71,22 @@ function RootStack() {
   useGuardedRedirect(ready && introDone && themeHydrated, session);
 
   return (
-    <>
+    <View style={styles.root}>
       <StatusBar style={mode === "dark" ? "light" : "dark"} />
+      {/* Mesh sits behind every route so glass surfaces have texture to blur. */}
+      {/* Mesh fica atras de tudo pra o glass ter algo pra borrar. */}
+      <MeshBackground />
       {!introDone ? (
         <IntroVideo onFinished={() => setIntroDone(true)} />
       ) : !ready || !themeHydrated || !fontsLoaded ? null : (
         <Stack
           screenOptions={{
-            headerStyle: { backgroundColor: colors.bg },
+            // contentStyle transparent so MeshBackground shows through every route.
+            // contentStyle transparente: deixa o MeshBackground aparecer atras.
+            headerStyle: { backgroundColor: "transparent" },
+            headerTransparent: true,
             headerTintColor: colors.text,
-            contentStyle: { backgroundColor: colors.bg },
+            contentStyle: { backgroundColor: "transparent" },
           }}
         >
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
@@ -64,9 +94,13 @@ function RootStack() {
           <Stack.Screen name="lead/[id]" options={{ title: "Lead" }} />
         </Stack>
       )}
-    </>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+});
 
 // useGuardedRedirect sends unauthenticated users to /login and authenticated
 // users away from /login to the tab root.

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -71,7 +71,11 @@ function RootStack() {
   useGuardedRedirect(ready && introDone && themeHydrated, session);
 
   return (
-    <View style={styles.root}>
+    // Solid bg colors.bg before the mesh paints — without this, the system
+    // fallback (white on web, sometimes on RN-screens) flashes through if the
+    // mesh layer is delayed by a frame. Mesh + glass surfaces still render on top.
+    // Bg solido como rede de seguranca; sem isso, branco do sistema pisca.
+    <View style={[styles.root, { backgroundColor: colors.bg }]}>
       <StatusBar style={mode === "dark" ? "light" : "dark"} />
       {/* Mesh sits behind every route so glass surfaces have texture to blur. */}
       {/* Mesh fica atras de tudo pra o glass ter algo pra borrar. */}

--- a/app/lead/[id].tsx
+++ b/app/lead/[id].tsx
@@ -1,6 +1,12 @@
+// Lead detail — Glass Minimalist redesign (Fase 2, screen 5/6).
+// Header: labelCaps "LEAD" + VIN mono large + priority/status badges.
+// Body: glass sections for reason and value.
+// Footer: glass thick fixed at the bottom with 3 actions.
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   LayoutChangeEvent,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -10,10 +16,9 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router, useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 
-import { Button } from "@/components/ui/Button";
-import { Card } from "@/components/ui/Card";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { FooterAction } from "@/components/ui/FooterAction";
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Toast, type ToastVariant } from "@/components/ui/Toast";
 import { useTheme } from "@/context/ThemeContext";
@@ -22,6 +27,7 @@ import { api, ApiError, type Lead } from "@/lib/api";
 import { formatBRL } from "@/lib/format";
 import { formatRelativeTime } from "@/lib/relative-time";
 import {
+  fontFamily,
   leadPriorityPalette,
   leadStatusPalette,
   radius,
@@ -100,17 +106,16 @@ export default function LeadDetailScreen() {
 
   if (loading && !lead) {
     return (
-      <View style={[styles.container, { paddingTop: insets.top + spacing.lg }]}>
+      <View style={[styles.container, { paddingTop: insets.top + spacing["3xl"] }]}>
         <View style={styles.scroll}>
-          <Skeleton width={240} height={28} borderRadius={radius.sm} />
-          <View style={styles.skeletonRow}>
-            <Skeleton width={84} height={28} borderRadius={radius.sm} />
-            <Skeleton width={84} height={28} borderRadius={radius.sm} />
-          </View>
-          <Skeleton width={140} height={16} borderRadius={radius.sm} />
           <Skeleton width={120} height={14} borderRadius={radius.sm} />
-          <Skeleton width="100%" height={64} borderRadius={radius.lg} />
-          <Skeleton width="100%" height={120} borderRadius={radius.lg} />
+          <Skeleton width={240} height={32} borderRadius={radius.sm} />
+          <View style={styles.skeletonRow}>
+            <Skeleton width={84} height={28} borderRadius={radius.pill} />
+            <Skeleton width={84} height={28} borderRadius={radius.pill} />
+          </View>
+          <Skeleton width="100%" height={120} borderRadius={radius.xl} />
+          <Skeleton width="100%" height={96} borderRadius={radius.xl} />
         </View>
       </View>
     );
@@ -119,9 +124,19 @@ export default function LeadDetailScreen() {
   if (error) {
     return (
       <View style={[styles.container, { paddingTop: insets.top + spacing["3xl"] }]}>
-        <ErrorBanner message={error} onRetry={() => void load()} />
+        <View style={styles.errorWrap}>
+          <ErrorBanner message={error} onRetry={() => void load()} />
+        </View>
         <View style={styles.notFoundActions}>
-          <Button label={t("common.back")} variant="ghost" onPress={() => router.back()} />
+          <Pressable
+            onPress={() => router.back()}
+            style={({ pressed }) => [
+              styles.backPill,
+              pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
+            ]}
+          >
+            <Text style={styles.backPillLabel}>{t("common.back")}</Text>
+          </Pressable>
         </View>
       </View>
     );
@@ -131,9 +146,15 @@ export default function LeadDetailScreen() {
     return (
       <View style={[styles.center, { paddingTop: insets.top }]}>
         <Text style={styles.muted}>{t("lead.not_found")}</Text>
-        <View style={styles.notFoundActions}>
-          <Button label={t("common.back")} variant="primary" onPress={() => router.back()} />
-        </View>
+        <Pressable
+          onPress={() => router.back()}
+          style={({ pressed }) => [
+            styles.backPillPrimary,
+            pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
+          ]}
+        >
+          <Text style={styles.backPillPrimaryLabel}>{t("common.back")}</Text>
+        </Pressable>
       </View>
     );
   }
@@ -143,25 +164,33 @@ export default function LeadDetailScreen() {
   const relativeTime = formatRelativeTime(lead.created_at, t);
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={styles.container}>
       <ScrollView
         contentContainerStyle={[
           styles.scroll,
-          { paddingBottom: insets.bottom + footerHeight + spacing.md },
+          {
+            paddingTop: insets.top + spacing["3xl"],
+            paddingBottom: insets.bottom + footerHeight + spacing.lg,
+          },
         ]}
         showsVerticalScrollIndicator={false}
       >
+        <Text style={styles.labelCaps}>{t("lead.priority")}</Text>
         <Text style={styles.vin} numberOfLines={1}>
           {lead.vin ?? "—"}
         </Text>
 
         <View style={styles.badgesRow}>
-          <View style={[styles.badge, { backgroundColor: priority.bg, borderColor: priority.border }]}>
+          <View
+            style={[styles.badge, { backgroundColor: priority.bg, borderColor: priority.border }]}
+          >
             <Text style={[styles.badgeLabel, { color: priority.color }]}>
               {t(priority.labelKey)}
             </Text>
           </View>
-          <View style={[styles.badge, { backgroundColor: status.bg, borderColor: status.border }]}>
+          <View
+            style={[styles.badge, { backgroundColor: status.bg, borderColor: status.border }]}
+          >
             <Text style={[styles.badgeLabel, { color: status.color }]}>
               {t(status.labelKey)}
             </Text>
@@ -170,49 +199,60 @@ export default function LeadDetailScreen() {
 
         {relativeTime ? (
           <Text style={styles.created}>
-            {t("lead.section.created")}: {relativeTime}
+            {t("lead.section.created")} · {relativeTime}
           </Text>
         ) : null}
 
         {lead.reason ? (
-          <View style={styles.section}>
-            <Text style={styles.sectionLabel}>{t("lead.section.reason")}</Text>
-            <Text style={styles.sectionBody}>{lead.reason}</Text>
-          </View>
+          <GlassSurface variant="thin" radius={20} style={styles.glassSection}>
+            <View style={styles.glassSectionInner}>
+              <Text style={styles.sectionLabel}>{t("lead.section.reason")}</Text>
+              <Text style={styles.sectionBody}>{lead.reason}</Text>
+            </View>
+          </GlassSurface>
         ) : null}
 
         {lead.expected_value_brl != null ? (
-          <Card style={styles.valueCard}>
-            <Text style={styles.sectionLabel}>{t("lead.section.value")}</Text>
-            <Text style={styles.valueBig}>{formatBRL(lead.expected_value_brl)}</Text>
-          </Card>
+          <GlassSurface variant="thin" radius={20} style={styles.glassSection}>
+            <View style={styles.glassSectionInner}>
+              <Text style={styles.sectionLabel}>{t("lead.section.value")}</Text>
+              <Text style={styles.valueBig}>{formatBRL(lead.expected_value_brl)}</Text>
+            </View>
+          </GlassSurface>
         ) : null}
       </ScrollView>
 
-      {/* Footer fixo: stubs honestos (disabled + "Em breve") ate o backend expor as acoes. */}
-      <View
-        style={[styles.footer, { paddingBottom: insets.bottom + spacing.md }]}
-        onLayout={onFooterLayout}
+      {/* Footer fixo glass thick. Stubs honestos (disabled + "Em breve"). */}
+      <GlassSurface
+        variant="thick"
+        radius={0}
+        border={false}
+        style={styles.footerWrap}
       >
-        <FooterAction
-          icon="call-outline"
-          label={t("lead.actions.call")}
-          onPress={() => onComingSoonAction("lead.actions.call")}
-          disabled
-        />
-        <FooterAction
-          icon="chatbubble-ellipses-outline"
-          label={t("lead.actions.message")}
-          onPress={() => onComingSoonAction("lead.actions.message")}
-          disabled
-        />
-        <FooterAction
-          icon="checkmark-circle-outline"
-          label={t("lead.actions.mark_contacted")}
-          onPress={() => onComingSoonAction("lead.actions.mark_contacted")}
-          disabled
-        />
-      </View>
+        <View
+          style={[styles.footer, { paddingBottom: insets.bottom + spacing.md }]}
+          onLayout={onFooterLayout}
+        >
+          <FooterAction
+            icon="call-outline"
+            label={t("lead.actions.call")}
+            onPress={() => onComingSoonAction("lead.actions.call")}
+            disabled
+          />
+          <FooterAction
+            icon="chatbubble-ellipses-outline"
+            label={t("lead.actions.message")}
+            onPress={() => onComingSoonAction("lead.actions.message")}
+            disabled
+          />
+          <FooterAction
+            icon="checkmark-circle-outline"
+            label={t("lead.actions.mark_contacted")}
+            onPress={() => onComingSoonAction("lead.actions.mark_contacted")}
+            disabled
+          />
+        </View>
+      </GlassSurface>
 
       <Toast
         message={toast.message}
@@ -226,17 +266,23 @@ export default function LeadDetailScreen() {
 
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { flex: 1, backgroundColor: c.bg },
+    container: { flex: 1, backgroundColor: "transparent" },
     scroll: {
-      padding: spacing.xl,
-      gap: spacing.lg,
+      paddingHorizontal: spacing["2xl"],
+      gap: spacing.md,
+    },
+    labelCaps: {
+      ...typography.labelCaps,
+      color: c.textMuted,
     },
     vin: {
       ...typography.mono,
-      fontSize: 22,
+      fontSize: 32,
+      lineHeight: 36,
       color: c.text,
       fontWeight: "700",
-      letterSpacing: -0.2,
+      letterSpacing: -0.4,
+      marginBottom: spacing.sm,
     },
     badgesRow: {
       flexDirection: "row",
@@ -245,7 +291,7 @@ function createStyles(c: ThemeColors) {
     badge: {
       paddingHorizontal: spacing.md,
       paddingVertical: spacing.xs + 2,
-      borderRadius: radius.sm,
+      borderRadius: radius.pill,
       borderWidth: 1,
     },
     badgeLabel: {
@@ -253,49 +299,43 @@ function createStyles(c: ThemeColors) {
       textTransform: "uppercase",
       letterSpacing: 0.6,
     },
-    section: {
-      gap: spacing.sm,
+    created: {
+      ...typography.caption,
+      color: c.textSubtle,
+      marginBottom: spacing.md,
     },
+    glassSection: { marginBottom: spacing.sm },
+    glassSectionInner: { padding: spacing.lg, gap: spacing.sm },
     sectionLabel: {
-      ...typography.label,
+      ...typography.labelCaps,
       color: c.textMuted,
-      textTransform: "uppercase",
     },
     sectionBody: {
       ...typography.body,
       color: c.text,
     },
-    valueCard: {
-      gap: spacing.sm,
-    },
     valueBig: {
-      ...typography.mono,
-      fontSize: 32,
-      color: c.primary,
-      fontWeight: "800",
-      letterSpacing: -0.4,
+      fontFamily: fontFamily.semibold,
+      fontSize: 36,
+      letterSpacing: -0.8,
+      color: c.text,
     },
-    created: {
-      ...typography.caption,
-      color: c.textSubtle,
-    },
-    footer: {
+    footerWrap: {
       position: "absolute",
       left: 0,
       right: 0,
       bottom: 0,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: c.glassBorder,
+    },
+    footer: {
       flexDirection: "row",
       gap: spacing.sm,
       paddingHorizontal: spacing.xl,
       paddingTop: spacing.md,
-      backgroundColor: c.surface,
-      borderTopWidth: 1,
-      borderTopColor: c.border,
     },
-    skeletonRow: {
-      flexDirection: "row",
-      gap: spacing.sm,
-    },
+    errorWrap: { paddingHorizontal: spacing["2xl"] },
+    skeletonRow: { flexDirection: "row", gap: spacing.sm },
     muted: { ...typography.body, color: c.textMuted },
     center: {
       flex: 1,
@@ -303,11 +343,34 @@ function createStyles(c: ThemeColors) {
       justifyContent: "center",
       padding: spacing.xl,
       gap: spacing.lg,
-      backgroundColor: c.bg,
     },
     notFoundActions: {
       marginTop: spacing.lg,
-      paddingHorizontal: spacing.xl,
+      paddingHorizontal: spacing["2xl"],
+    },
+    backPill: {
+      alignSelf: "flex-start",
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing["2xl"],
+      borderRadius: radius.pill,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: c.borderStrong,
+    },
+    backPillLabel: {
+      ...typography.body,
+      fontFamily: fontFamily.semibold,
+      color: c.text,
+    },
+    backPillPrimary: {
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing["3xl"],
+      borderRadius: radius.pill,
+      backgroundColor: c.primary,
+    },
+    backPillPrimaryLabel: {
+      ...typography.body,
+      fontFamily: fontFamily.semibold,
+      color: c.primaryText,
     },
   });
 }

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,5 +1,13 @@
+// Login — Glass Minimalist redesign (Fase 2, screen 1/6).
+// Inputs are intentionally inline (not the shared Input component) per the
+// "screen-by-screen first, componentize later" workflow. Same goes for the
+// CTA — bare Pressable pill instead of the shared Button.
+//
+// Login redesenhado: inputs underline + pill CTA inline (sem componentes).
+
 import { useMemo, useRef, useState } from "react";
 import {
+  ActivityIndicator,
   Animated,
   KeyboardAvoidingView,
   Platform,
@@ -7,21 +15,20 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
-import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
 import { Toast, type ToastVariant } from "@/components/ui/Toast";
 import { useTheme } from "@/context/ThemeContext";
 import { useFadeIn } from "@/hooks/useFadeIn";
 import { useShake } from "@/hooks/useShake";
 import { signInWithEmail } from "@/lib/auth";
 import { haptic } from "@/lib/haptics";
-import { fontWeight, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { fontFamily, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 import {
   validateEmail,
   validatePassword,
@@ -50,8 +57,6 @@ export default function LoginScreen() {
   const { translateX, shake } = useShake();
   const { opacity, translateY } = useFadeIn(360);
 
-  // Scale-in for the header — sits on top of the fade. Subtle (0.96 -> 1).
-  // Scale leve junto do fade pra entrada mais viva.
   const scale = useRef(new Animated.Value(0.96)).current;
   useMemo(() => {
     Animated.spring(scale, {
@@ -65,6 +70,8 @@ export default function LoginScreen() {
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [emailFocused, setEmailFocused] = useState(false);
+  const [passwordFocused, setPasswordFocused] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -118,7 +125,7 @@ export default function LoginScreen() {
       <ScrollView
         contentContainerStyle={[
           styles.scroll,
-          { paddingTop: insets.top + spacing["4xl"], paddingBottom: insets.bottom + spacing["2xl"] },
+          { paddingTop: insets.top + spacing["5xl"], paddingBottom: insets.bottom + spacing["3xl"] },
         ]}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
@@ -130,38 +137,41 @@ export default function LoginScreen() {
           ]}
         >
           <Text style={styles.brand}>FORD</Text>
-          <Text style={styles.title}>{t("app.name")}</Text>
-          <Text style={styles.subtitle}>{t("auth.subtitle")}</Text>
+          <Text style={styles.tagline}>{t("auth.subtitle")}</Text>
         </Animated.View>
 
-        <View style={styles.form}>
-          <Input
+        <Animated.View style={[styles.form, { transform: [{ translateX }] }]}>
+          <UnderlineInput
+            colors={colors}
             label={t("auth.email")}
-            placeholder={t("auth.email_placeholder")}
-            icon="mail-outline"
             value={email}
             onChangeText={setEmail}
+            placeholder={t("auth.email_placeholder")}
             keyboardType="email-address"
             autoCapitalize="none"
             autoCorrect={false}
             autoComplete="email"
-            shakeAnim={translateX}
+            focused={emailFocused}
+            onFocus={() => setEmailFocused(true)}
+            onBlur={() => setEmailFocused(false)}
             error={
               visibleErrors.email
                 ? t(visibleErrors.email.key, visibleErrors.email.vars)
                 : undefined
             }
           />
-          <Input
+          <UnderlineInput
+            colors={colors}
             label={t("auth.password")}
-            placeholder="••••••"
-            icon="lock-closed-outline"
             value={password}
             onChangeText={setPassword}
+            placeholder="••••••"
             secureTextEntry
             autoCapitalize="none"
             autoComplete="password"
-            shakeAnim={translateX}
+            focused={passwordFocused}
+            onFocus={() => setPasswordFocused(true)}
+            onBlur={() => setPasswordFocused(false)}
             error={
               visibleErrors.password
                 ? t(visibleErrors.password.key, visibleErrors.password.vars)
@@ -170,30 +180,42 @@ export default function LoginScreen() {
           />
 
           {serverError ? (
-            <View style={styles.serverErrorBox}>
-              <Text style={styles.serverErrorText}>{serverError}</Text>
-            </View>
+            <Text style={styles.serverErrorText}>{serverError}</Text>
           ) : null}
+        </Animated.View>
 
-          <Button
-            label={t("auth.sign_in")}
-            loadingLabel={t("auth.signing_in")}
-            loading={loading}
-            disabled={buttonDisabled}
+        <View style={styles.footer}>
+          <Pressable
             onPress={onSubmit}
-            style={styles.submit}
-          />
-        </View>
+            disabled={buttonDisabled || loading}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: buttonDisabled || loading, busy: loading }}
+            style={({ pressed }) => [
+              styles.pillCTA,
+              (buttonDisabled || loading) && styles.pillCTADisabled,
+              pressed && styles.pillCTAPressed,
+            ]}
+          >
+            {loading ? (
+              <View style={styles.pillCTALoading}>
+                <ActivityIndicator color={colors.primaryText} />
+                <Text style={styles.pillCTALabel}>{t("auth.signing_in")}</Text>
+              </View>
+            ) : (
+              <Text style={styles.pillCTALabel}>{t("auth.sign_in")}</Text>
+            )}
+          </Pressable>
 
-        <Pressable
-          onPress={onForgotPassword}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel={t("auth.forgot_password")}
-          style={({ pressed }) => [styles.forgotWrap, pressed && { opacity: 0.6 }]}
-        >
-          <Text style={styles.forgotLabel}>{t("auth.forgot_password")}</Text>
-        </Pressable>
+          <Pressable
+            onPress={onForgotPassword}
+            hitSlop={12}
+            accessibilityRole="button"
+            accessibilityLabel={t("auth.forgot_password")}
+            style={({ pressed }) => [styles.forgotWrap, pressed && { opacity: 0.6 }]}
+          >
+            <Text style={styles.forgotLabel}>{t("auth.forgot_password")}</Text>
+          </Pressable>
+        </View>
       </ScrollView>
 
       <Toast
@@ -206,59 +228,143 @@ export default function LoginScreen() {
   );
 }
 
+// Inline minimal underline input. Lives here for now per the screen-by-screen
+// workflow; gets extracted to a shared <UnderlineInput> in Phase 3.
+type UnderlineInputProps = {
+  colors: ThemeColors;
+  label: string;
+  value: string;
+  onChangeText: (s: string) => void;
+  placeholder?: string;
+  focused: boolean;
+  onFocus: () => void;
+  onBlur: () => void;
+  error?: string;
+  secureTextEntry?: boolean;
+  keyboardType?: "default" | "email-address";
+  autoCapitalize?: "none" | "sentences";
+  autoCorrect?: boolean;
+  autoComplete?: "email" | "password";
+};
+
+function UnderlineInput({
+  colors,
+  label,
+  value,
+  onChangeText,
+  placeholder,
+  focused,
+  onFocus,
+  onBlur,
+  error,
+  secureTextEntry,
+  keyboardType,
+  autoCapitalize,
+  autoCorrect,
+  autoComplete,
+}: UnderlineInputProps) {
+  const lineColor = error ? colors.error : focused ? colors.text : colors.border;
+  return (
+    <View style={inputStyles.wrap}>
+      <Text style={[inputStyles.label, { color: colors.textMuted }]}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.textSubtle}
+        secureTextEntry={secureTextEntry}
+        keyboardType={keyboardType}
+        autoCapitalize={autoCapitalize}
+        autoCorrect={autoCorrect}
+        autoComplete={autoComplete}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        style={[
+          inputStyles.input,
+          { color: colors.text, borderBottomColor: lineColor },
+        ]}
+      />
+      {error ? (
+        <Text style={[inputStyles.error, { color: colors.error }]}>{error}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const inputStyles = StyleSheet.create({
+  wrap: { marginBottom: spacing.xl },
+  label: {
+    ...typography.labelCaps,
+    marginBottom: spacing.xs,
+  },
+  input: {
+    ...typography.bodyLg,
+    paddingVertical: spacing.sm + 2,
+    borderBottomWidth: StyleSheet.hairlineWidth + 0.5,
+  },
+  error: {
+    ...typography.caption,
+    marginTop: spacing.xs,
+  },
+});
+
 function createStyles(c: ThemeColors) {
   return StyleSheet.create({
-    container: { flex: 1, backgroundColor: c.bg },
+    // Transparent so the MeshBackground at the root shows through.
+    container: { flex: 1, backgroundColor: "transparent" },
     scroll: {
       flexGrow: 1,
-      paddingHorizontal: spacing.xl,
-      justifyContent: "center",
+      paddingHorizontal: spacing["2xl"],
+      justifyContent: "space-between",
     },
     header: {
-      alignItems: "center",
-      marginBottom: spacing["2xl"],
-      gap: spacing.xs,
+      alignItems: "flex-start",
+      marginBottom: spacing["4xl"],
+      gap: spacing.lg,
     },
     brand: {
-      fontSize: 40,
-      fontWeight: fontWeight.extrabold,
-      letterSpacing: 6,
-      color: c.primary,
-      marginBottom: spacing.md,
+      fontFamily: fontFamily.bold,
+      fontSize: 72,
+      letterSpacing: 8,
+      color: c.text,
+      lineHeight: 72,
     },
-    title: { ...typography.h1, color: c.text },
-    subtitle: {
-      ...typography.body,
+    tagline: {
+      ...typography.bodyLg,
       color: c.textMuted,
-      textAlign: "center",
-      paddingHorizontal: spacing.lg,
+      maxWidth: 320,
     },
     form: { width: "100%" },
-    serverErrorBox: {
-      borderWidth: 1,
-      borderColor: c.error,
-      backgroundColor: c.errorSoft,
-      borderRadius: radius.md,
-      padding: spacing.md,
-      marginTop: spacing.xs,
-      marginBottom: spacing.md,
-    },
     serverErrorText: {
       ...typography.caption,
-      fontWeight: "600",
       color: c.error,
-      textAlign: "center",
+      marginTop: spacing.sm,
     },
-    submit: { marginTop: spacing.md },
+    footer: { gap: spacing.sm, marginTop: spacing["3xl"] },
+    pillCTA: {
+      height: 56,
+      borderRadius: radius.pill,
+      backgroundColor: c.primary,
+      alignItems: "center",
+      justifyContent: "center",
+      flexDirection: "row",
+    },
+    pillCTADisabled: { opacity: 0.45 },
+    pillCTAPressed: { opacity: 0.92, transform: [{ scale: 0.98 }] },
+    pillCTALoading: { flexDirection: "row", alignItems: "center", gap: spacing.sm },
+    pillCTALabel: {
+      ...typography.bodyLg,
+      fontFamily: fontFamily.semibold,
+      color: c.primaryText,
+    },
     forgotWrap: {
       alignItems: "center",
       paddingVertical: spacing.lg,
-      marginTop: spacing.md,
     },
     forgotLabel: {
       ...typography.caption,
-      color: c.primary,
-      fontWeight: "600",
+      fontFamily: fontFamily.medium,
+      color: c.textMuted,
     },
   });
 }

--- a/components/domain/LeadCard.tsx
+++ b/components/domain/LeadCard.tsx
@@ -5,15 +5,15 @@
 //   1. Priority chip (colored, uppercase) on the left + relative time on the right
 //   2. VIN in mono semibold
 //   3. Reason in body textMuted (optional)
-//   4. Status dot + label on the left + expected value (mono, primary color) on the right
-// Pressable wraps the whole thing; haptic light on press; scale 0.99 on press.
-// Card de lead na lista: stripe + chip + VIN mono + razao + status + valor.
+//   4. Status dot + label on the left + expected value (mono primary text) on the right
+// Wrapped in GlassSurface (thin variant) so it sits on top of the mesh bg.
+// Card de lead: stripe + chip + VIN mono + razao + status + valor sobre glass.
 
 import React, { useMemo, useRef } from "react";
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
-import { Card } from "@/components/ui/Card";
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { useTheme } from "@/context/ThemeContext";
 import { haptic } from "@/lib/haptics";
 import type { Lead } from "@/lib/api";
@@ -64,7 +64,7 @@ export function LeadCard({ lead, onPress }: LeadCardProps) {
   };
 
   const cardBody = (
-    <Card style={styles.card}>
+    <GlassSurface variant="thin" radius={18} style={styles.card}>
       <View style={[styles.stripe, { backgroundColor: priority.color }]} />
       <View style={styles.body}>
         <View style={styles.row}>
@@ -104,7 +104,7 @@ export function LeadCard({ lead, onPress }: LeadCardProps) {
           ) : null}
         </View>
       </View>
-    </Card>
+    </GlassSurface>
   );
 
   if (!onPress) return cardBody;
@@ -197,7 +197,7 @@ function createStyles(c: ThemeColors) {
     },
     value: {
       ...typography.mono,
-      color: c.primary,
+      color: c.text,
       fontWeight: "700",
     },
   });

--- a/components/ui/FooterAction.tsx
+++ b/components/ui/FooterAction.tsx
@@ -1,7 +1,7 @@
-// FooterAction: botao primario de footer fixo. Usado na tela de detalhe do
-// lead pra agrupar 3 acoes lado a lado (Ligar, Mensagem, Marcar contato).
-// Quando `disabled`, renderiza badge "Em breve" abaixo do label e bloqueia
-// onPress + haptic, sem fingir que a acao acontece.
+// FooterAction: pressable column for the fixed glass footer in lead detail.
+// Three of these sit side-by-side (Ligar / Mensagem / Marcar contato).
+// When `disabled`, renders a small "Em breve" hint and blocks onPress, so we
+// never lie about what works.
 
 import { Ionicons } from "@expo/vector-icons";
 import { useMemo } from "react";
@@ -9,7 +9,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 import { useTheme } from "@/context/ThemeContext";
-import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { fontFamily, radius, spacing, typography, type ThemeColors } from "@/lib/theme";
 
 export interface FooterActionProps {
   icon: keyof typeof Ionicons.glyphMap;
@@ -37,14 +37,17 @@ export function FooterAction({
       disabled={disabled}
       style={({ pressed }) => [
         styles.btn,
-        disabled && styles.btnDisabled,
         pressed && !disabled && { opacity: 0.7 },
       ]}
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ disabled }}
     >
-      <Ionicons name={icon} size={20} color={disabled ? colors.textSubtle : colors.primary} />
+      <Ionicons
+        name={icon}
+        size={22}
+        color={disabled ? colors.textSubtle : colors.text}
+      />
       <Text
         style={[styles.label, disabled && { color: colors.textSubtle }]}
         numberOfLines={1}
@@ -70,25 +73,21 @@ function createStyles(c: ThemeColors) {
       alignItems: "center",
       justifyContent: "center",
       gap: spacing.xs,
-      backgroundColor: c.primarySoft,
-    },
-    btnDisabled: {
-      backgroundColor: c.surfaceElevated,
-      opacity: 0.7,
+      backgroundColor: "transparent",
     },
     label: {
       ...typography.caption,
-      fontWeight: "700",
-      color: c.primary,
+      fontFamily: fontFamily.semibold,
+      color: c.text,
     },
     hint: {
       marginTop: 2,
-      paddingHorizontal: spacing.xs,
+      paddingHorizontal: spacing.sm,
       paddingVertical: 1,
       borderRadius: radius.sm,
-      backgroundColor: c.surface,
-      borderWidth: 1,
-      borderColor: c.border,
+      backgroundColor: c.glassBase,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: c.glassBorder,
     },
     hintLabel: {
       ...typography.label,

--- a/components/ui/GlassSurface.tsx
+++ b/components/ui/GlassSurface.tsx
@@ -1,0 +1,84 @@
+// Glass surface — semi-transparent + blur. Abstraction over platform diffs:
+//   iOS / web   -> expo-blur BlurView (web: backdrop-filter via the lib)
+//   Android     -> rgba fill only (real blur is jank in long lists on Android)
+//
+// Variants control blur intensity + opacity. Use `regular` by default,
+// `thin` for nested surfaces, `thick` for sheets and modals.
+//
+// Superficie glass: blur real no iOS/web; fill rgba no Android (perf).
+
+import { useMemo, type ReactNode } from "react";
+import { Platform, StyleSheet, View, type ViewStyle } from "react-native";
+import { BlurView } from "expo-blur";
+
+import { useTheme } from "@/context/ThemeContext";
+
+export type GlassVariant = "thin" | "regular" | "thick";
+
+export interface GlassSurfaceProps {
+  variant?: GlassVariant;
+  radius?: number;
+  border?: boolean;
+  style?: ViewStyle | ViewStyle[];
+  children?: ReactNode;
+}
+
+const INTENSITY: Record<GlassVariant, number> = {
+  thin: 30,
+  regular: 60,
+  thick: 90,
+};
+
+// Android falls back to fill-only — these alphas keep parity with the visual
+// weight of the blur intensities above.
+const ANDROID_ALPHA: Record<GlassVariant, number> = {
+  thin: 0.45,
+  regular: 0.6,
+  thick: 0.78,
+};
+
+export function GlassSurface({
+  variant = "regular",
+  radius = 20,
+  border = true,
+  style,
+  children,
+}: GlassSurfaceProps) {
+  const { colors, mode } = useTheme();
+
+  const containerStyle = useMemo<ViewStyle>(
+    () => ({
+      borderRadius: radius,
+      overflow: "hidden",
+      borderWidth: border ? StyleSheet.hairlineWidth : 0,
+      borderColor: colors.glassBorder,
+      backgroundColor: Platform.OS === "android" ? androidFill(mode, variant) : "transparent",
+    }),
+    [radius, border, colors.glassBorder, mode, variant],
+  );
+
+  if (Platform.OS === "android") {
+    return <View style={[containerStyle, style]}>{children}</View>;
+  }
+
+  // BlurView for iOS + web (expo-blur uses backdrop-filter on web).
+  // tint='default' adapts to theme; we pass dark/light explicitly so the
+  // glass reads correctly even when device theme disagrees with app theme.
+  return (
+    <View style={[containerStyle, style]}>
+      <BlurView
+        intensity={INTENSITY[variant]}
+        tint={mode === "dark" ? "dark" : "light"}
+        style={StyleSheet.absoluteFill}
+      />
+      {children}
+    </View>
+  );
+}
+
+function androidFill(mode: "light" | "dark", variant: GlassVariant): string {
+  const alpha = ANDROID_ALPHA[variant];
+  return mode === "dark"
+    ? `rgba(40, 40, 40, ${alpha})`
+    : `rgba(255, 255, 255, ${alpha})`;
+}

--- a/components/ui/MeshBackground.tsx
+++ b/components/ui/MeshBackground.tsx
@@ -1,0 +1,61 @@
+// Mesh gradient background — fixed at the root, sits behind every screen so
+// the glass surfaces have texture to blur into. Three radial-style layers
+// (top-left, top-right, bottom) over a flat base color. Static, no animation.
+//
+// Bg mesh fixo no root: 3 camadas de gradiente sobre cor base. Sem animacao.
+
+import { useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+import { useTheme } from "@/context/ThemeContext";
+
+type MeshConfig = {
+  base: string;
+  topLeft: [string, string];
+  topRight: [string, string];
+  bottom: [string, string];
+};
+
+const MESH: Record<"light" | "dark", MeshConfig> = {
+  dark: {
+    base: "#161616",
+    topLeft: ["rgba(40, 40, 55, 0.35)", "rgba(40, 40, 55, 0)"],
+    topRight: ["rgba(60, 40, 40, 0.20)", "rgba(60, 40, 40, 0)"],
+    bottom: ["rgba(30, 30, 35, 0)", "rgba(22, 22, 22, 0.45)"],
+  },
+  light: {
+    base: "#F0F0F2",
+    topLeft: ["rgba(220, 220, 235, 0.50)", "rgba(220, 220, 235, 0)"],
+    topRight: ["rgba(245, 240, 235, 0.35)", "rgba(245, 240, 235, 0)"],
+    bottom: ["rgba(240, 240, 242, 0)", "rgba(240, 240, 242, 0.40)"],
+  },
+};
+
+export function MeshBackground() {
+  const { mode } = useTheme();
+  const cfg = useMemo(() => MESH[mode], [mode]);
+
+  return (
+    <View style={[StyleSheet.absoluteFill, { backgroundColor: cfg.base }]} pointerEvents="none">
+      <LinearGradient
+        colors={cfg.topLeft}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0.7, y: 0.6 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={cfg.topRight}
+        start={{ x: 1, y: 0 }}
+        end={{ x: 0.3, y: 0.6 }}
+        style={StyleSheet.absoluteFill}
+      />
+      <LinearGradient
+        colors={cfg.bottom}
+        start={{ x: 0.5, y: 0.4 }}
+        end={{ x: 0.5, y: 1 }}
+        style={StyleSheet.absoluteFill}
+      />
+    </View>
+  );
+}

--- a/components/ui/SettingRow.tsx
+++ b/components/ui/SettingRow.tsx
@@ -1,13 +1,15 @@
 // SettingRow: linha de configuracao com icone + label/value + slot direito.
-// Reutilizada na tela de perfil (tema, idioma) e qualquer outra que precise
-// expor uma propriedade com explicacao secundaria + controle inline.
+// Reescrita pro Glass Minimalist: transparent (sem wrapping de card), opt-in
+// divider hairline pra ser usada dentro de um group GlassSurface no Profile.
+//
+// Layout: [iconWrap 36x36] [label\nvalue] [right slot]
 
 import { Ionicons } from "@expo/vector-icons";
 import { useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import { useTheme } from "@/context/ThemeContext";
-import { radius, spacing, typography, type ThemeColors } from "@/lib/theme";
+import { spacing, typography, type ThemeColors } from "@/lib/theme";
 
 export type SettingRowEmphasis = "label" | "value";
 
@@ -23,6 +25,8 @@ export interface SettingRowProps {
    * e o value e auxiliar ("Manual").
    */
   emphasis?: SettingRowEmphasis;
+  /** Show a hairline divider at the bottom — set true on all-but-last in a group. */
+  divider?: boolean;
 }
 
 export function SettingRow({
@@ -31,6 +35,7 @@ export function SettingRow({
   value,
   right,
   emphasis = "value",
+  divider,
 }: SettingRowProps) {
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
@@ -38,10 +43,15 @@ export function SettingRow({
   const valueStyle = emphasis === "label" ? styles.textSecondary : styles.textPrimary;
 
   return (
-    <View style={styles.row}>
+    <View
+      style={[
+        styles.row,
+        divider && { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.glassBorder },
+      ]}
+    >
       <View style={styles.left}>
         <View style={styles.iconWrap}>
-          <Ionicons name={icon} size={18} color={colors.primary} />
+          <Ionicons name={icon} size={18} color={colors.text} />
         </View>
         <View style={styles.textCol}>
           <Text style={labelStyle} numberOfLines={1}>
@@ -64,13 +74,9 @@ function createStyles(c: ThemeColors) {
       alignItems: "center",
       justifyContent: "space-between",
       gap: spacing.md,
-      marginHorizontal: spacing.xl,
-      marginBottom: spacing.md,
-      backgroundColor: c.surface,
-      borderRadius: radius.lg,
-      padding: spacing.lg,
-      borderWidth: 1,
-      borderColor: c.border,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.md + 2,
+      backgroundColor: "transparent",
     },
     left: {
       flex: 1,

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -50,7 +50,15 @@ function isThemeMode(value: string | null): value is ThemeMode {
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const systemScheme = useColorScheme();
-  const systemMode: ThemeMode = systemScheme === "light" ? "light" : "dark";
+  // Glass Minimalist design ships dark as the canonical mode. Users can opt
+  // into light via the Profile switch. Following the system would surprise
+  // anyone whose OS is in light by hiding the design's signature look, and
+  // react-native-web's useColorScheme misfires on Windows browsers.
+  // Default dark sempre; light eh opt-in via switch.
+  const systemMode: ThemeMode = "dark";
+  // Unused — kept on purpose so we can revisit follow-system if the product
+  // decides to honor it later. Avoids a noisy refactor when re-enabled.
+  void systemScheme;
 
   // override === null means "follow system"; otherwise it pins the mode.
   const [override, setOverride] = useState<ThemeMode | null>(null);

--- a/docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
+++ b/docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
@@ -1,0 +1,212 @@
+# Glass Minimalist — Design System Spec
+
+**Data:** 2026-05-23
+**Autor:** Jota + Claude Opus 4.7
+**Status:** approved, em implementacao
+
+## Motivacao
+
+O design anterior (Ford Blue agressivo + cards solidos + tipografia sans-only) nao alcancou o look minimalista premium que o produto pede. Refs visuais aprovados:
+
+- **Base estetica** (Mailchimp / Mobbin): label-caps minusculo + titulo serif gigante, hierarquia hiper-clara, cards com bordas leves, muito espaco em branco.
+- **Camada glass** (TIDE app): superficies semi-transparentes com blur ("frosted glass"), bg dark sutil quase preto, icones outline finos, CTAs brancos pill.
+
+Objetivo: combinar **Mailchimp em hierarquia tipografica** + **TIDE em superficies glass** sob a marca Ford (reduzida ao logo).
+
+## Decisoes fechadas
+
+| | Decisao |
+|---|---|
+| Modos | Light + dark com paridade total. Dark e a estrela. |
+| Ford Blue | So no wordmark/logo. UI = grayscale + branco. CTAs brancos (pill) em dark, pretos (pill) em light. |
+| Fontes | Fraunces (display serif variable) + Inter (sans body) via expo-google-fonts |
+| Glass | Agressivo (TIDE-style): cards, inputs, hero, tab bar, modais. Tudo |
+| BG | Mesh gradient abstrato estatico (sem foto, sem animacao). 3 radial gradients sobrepostos |
+
+## Tokens de cor
+
+### Dark
+```
+bg               #1E1E1E    (RGB 30,30,30 — pedido explicito)
+bgDeep           #161616    (sutilmente mais escuro pra mesh)
+bgElevated       #252525    (cards solidos elevados, fallback sem glass)
+glassBase        rgba(40,40,40,0.55)    + backdrop-blur 24px
+glassBorder      rgba(255,255,255,0.08)
+textPrimary      #F5F5F5    (nao puro branco)
+textMuted        #9CA3AF
+textSubtle       #6B7280
+separator        rgba(255,255,255,0.06)
+```
+
+### Light
+```
+bg               #FAFAFA    (off-white)
+bgDeep           #F0F0F2
+bgElevated       #FFFFFF
+glassBase        rgba(255,255,255,0.65)    + backdrop-blur 24px
+glassBorder      rgba(0,0,0,0.06)
+textPrimary      #1A1A1A
+textMuted        #6B7280
+textSubtle       #9CA3AF
+separator        rgba(0,0,0,0.05)
+```
+
+### Brand + semantic (compartilhado)
+```
+fordBlue         #003478    APENAS wordmark/logo. NUNCA UI.
+ctaDark          #FFFFFF    pill branco em dark
+ctaLight         #1A1A1A    pill preto em light
+success          #10B981
+warning          #F59E0B
+error            #EF4444
+critical         #FF453A    (Apple red)
+```
+
+## Tipografia
+
+```
+Display:  Fraunces (variable 100-900, soft, opt-sized)
+Body:     Inter (variable 100-900)
+Mono:     SF Mono / Cascadia / Consolas (system stack, sem bundle)
+
+Escala:
+  h-display    40px  Fraunces 700  letter-spacing -1.2   titulos de tela
+  h-section    28px  Fraunces 600  letter-spacing -0.8   section headers
+  h3           18px  Inter 600                            subsections
+  body-lg      17px  Inter 400                            paragraphs
+  body         15px  Inter 400                            default
+  caption      13px  Inter 400
+  label-caps   11px  Inter 600     letter-spacing +1.0    Mailchimp uppercase
+  mono         15px  Mono 500
+```
+
+Bundle via `useFonts` em `_layout.tsx` (mesmo pattern de Ionicons).
+
+## Sistema de glass
+
+Componente `<GlassSurface>` abstrai por plataforma:
+
+```
+iOS native:     expo-blur BlurView intensity=80 + tint='regular'|'dark'
+Android native: rgba fill semi-transparent + borda glassBorder
+                (Android blur real tem perf ruim em listas)
+Web:            backdrop-filter: blur(24px) + bg glassBase + borda
+```
+
+Variantes:
+- `thin` — blur 12px, mais transparente, pra surfaces aninhadas
+- `regular` — blur 24px, padrao
+- `thick` — blur 40px, modais e sheets
+
+API:
+```tsx
+<GlassSurface variant="regular" radius={20}>
+  {children}
+</GlassSurface>
+```
+
+## Mesh gradient background
+
+Componente `<MeshBackground>` fixo no root, atras de tudo. Implementacao: `expo-linear-gradient` em 3 layers absoluteFill.
+
+```
+Dark:
+  base:        #161616
+  layer 1:     top-left,   rgba(40,40,55,0.35)  -> transparent
+  layer 2:     top-right,  rgba(60,40,40,0.20)  -> transparent
+  layer 3:     bottom,     rgba(30,30,35,0.45)  -> bgDeep
+
+Light:
+  base:        #F0F0F2
+  layer 1:     top-left,   rgba(220,220,235,0.50) -> transparent
+  layer 2:     top-right,  rgba(245,240,235,0.35) -> transparent
+  layer 3:     bottom,     rgba(240,240,242,0.40) -> bgDeep
+```
+
+## Padroes por tela
+
+### Login
+- bg mesh + wordmark **FORD** Fraunces 56px branco
+- tagline Inter 15px muted abaixo
+- inputs underline-only (sem borda completa, sem card glass) — minimalista
+- CTA branco pill bottom + Esqueci senha em ghost
+
+### Home
+```
+[mesh bg]
+  HOJE                           label-caps 11
+  Bom dia, Jota                  Fraunces 40
+  ┌─────────────── glass ───────────────┐
+  │  LEADS ATIVOS    PIPELINE           │
+  │       12         R$ 1.2M            │
+  └─────────────────────────────────────┘
+  Leads recentes                 Fraunces 28
+  [glass card lead 1]
+  [glass card lead 2]
+  ...
+  [tab bar glass thick]
+```
+
+### Leads
+- Mesmo header pattern (label-caps + Fraunces titulo)
+- Search bar glass pill
+- Filter chips glass (active = solid white com text dark)
+- Lista de glass cards
+
+### Profile
+- Avatar 80px circular + nome Fraunces 28px + email Inter muted
+- Sections com label-caps + glass rows separadas por separator
+- Sem card wrapper, rows ficam direto sobre o mesh com glass
+
+### Lead detail
+- Header stack minimo
+- Label-caps `LEAD` + VIN mono grande
+- Status pill colored (mantem palette de status)
+- Glass sections de info
+- Footer fixed glass thick com 3 CTAs
+
+### Tab bar
+- Glass thick com 4 icones outline finos + 1 central destacado
+- Sem labels (ou labels so no active, estilo iOS)
+
+## Ordem de implementacao
+
+### Fase 1 — Foundation (1 PR)
+- `theme.ts`: novas paletas dark/light com tokens acima
+- `_layout.tsx`: useFonts(Fraunces + Inter)
+- `components/ui/MeshBackground.tsx`: novo componente fixo no root
+- `components/ui/GlassSurface.tsx`: novo componente com abstracao de blur
+
+### Fase 2 — Telas, 1 PR por tela, sem componentizar
+Estilos copiados inline em cada tela. Componentizacao vem depois.
+
+1. Login
+2. Home
+3. Leads
+4. Profile
+5. Lead detail
+6. Tab bar (glass)
+
+### Fase 3 — Componentizacao
+Depois que todas as telas estiverem certas:
+- `<ScreenTitle>` — label-caps + Fraunces titulo + opt subtitle
+- `<GlassCard>` — wrapper com variantes thin/regular/thick
+- `<PillButton>` — variantes solid/glass/ghost com pill radius
+- Refatorar telas pra usar novos componentes
+
+## Migracao das telas existentes
+
+Telas atuais ja tem:
+- ScreenHeader (deprecate por ScreenTitle na fase 3)
+- Card (deprecate por GlassCard na fase 3)
+- Button (manter, ganha variante `pill`)
+- ErrorBanner, EmptyState, Toast — mantem, ganham GlassSurface por dentro
+
+i18n keys nao mudam (so visuals).
+
+## Riscos e mitigacoes
+
+- **Performance do blur no Android**: usar fallback rgba semi-transparent. Testar em emulador antes de mergear cada PR.
+- **Bundle size das fontes**: Fraunces + Inter variable ~400KB combinado. Aceitavel pra UX premium.
+- **Web fallback do blur**: `backdrop-filter` tem suporte ~95% (caniuse). Browsers antigos veem rgba sem blur — degradacao OK.
+- **Mesh gradient em listas longas**: fixed atras de tudo, nao re-renderiza. Performance neutra.

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,28 +1,39 @@
-// Design tokens for the ForwardService mobile app.
-// Two palettes (light + dark) keyed by semantic tokens. Screens consume via
-// useTheme() — never import `palette` directly.
-// Tokens de design: paletas light/dark, espacamento, tipografia, elevacao.
+// Design tokens for the ForwardService mobile app — Glass Minimalist redesign.
+// Light + dark palettes keyed by semantic tokens. Screens consume via useTheme().
+// Spec: docs/superpowers/specs/2026-05-23-glass-minimalist-design.md
+//
+// Tokens de design: paletas light/dark, glass, tipografia Fraunces+Inter.
 
 import { Platform } from "react-native";
 
 export type ThemeMode = "light" | "dark";
 
 export type ThemeColors = {
+  // Base surfaces
   bg: string;
+  bgDeep: string;
   bgElevated: string;
   surface: string;
   surfaceElevated: string;
   surfaceHover: string;
+  // Glass (new): semi-transparent, paired with backdrop-blur at the consumer.
+  glassBase: string;
+  glassBorder: string;
+  // Borders + separators
   border: string;
   borderStrong: string;
   separator: string;
+  // Text
   text: string;
   textMuted: string;
   textSubtle: string;
+  // Primary CTA — white pill in dark, dark pill in light (TIDE-style).
+  // Brand fordBlue is exported separately and used ONLY in the wordmark.
   primary: string;
   primaryDeep: string;
   primaryText: string;
   primarySoft: string;
+  // Status / semantic
   success: string;
   successSoft: string;
   warning: string;
@@ -30,36 +41,38 @@ export type ThemeColors = {
   error: string;
   errorSoft: string;
   critical: string;
+  // Misc
   overlay: string;
   tabBar: string;
   inputBg: string;
 };
 
-// Ford Blue is the brand primary. Light uses the classic deep blue; dark uses
-// a lighter, more saturated variant for legibility on dark backgrounds.
-// Azul Ford classico (#003478) no light; variante mais clara no dark.
+// Ford Blue is the brand mark. Used ONLY on the FORD wordmark + logo glyph.
+// Never on CTAs, switches, tabs, or any interactive surface.
+// Azul Ford apenas no wordmark/logo. Nunca em UI interativa.
 export const FORD_BLUE = "#003478";
 export const FORD_BLUE_DEEP = "#002356";
-export const FORD_BLUE_DARK_MODE = "#5B8DEF";
-export const FORD_BLUE_DARK_MODE_DEEP = "#3D6FCC";
 
 export const palette: Record<ThemeMode, ThemeColors> = {
   light: {
-    bg: "#F7F8FA",
+    bg: "#FAFAFA",
+    bgDeep: "#F0F0F2",
     bgElevated: "#FFFFFF",
     surface: "#FFFFFF",
     surfaceElevated: "#FFFFFF",
-    surfaceHover: "#F1F3F7",
-    border: "rgba(11, 18, 32, 0.08)",
-    borderStrong: "rgba(11, 18, 32, 0.14)",
-    separator: "rgba(11, 18, 32, 0.05)",
-    text: "#0B1220",
-    textMuted: "#56627A",
-    textSubtle: "#8E97AC",
-    primary: FORD_BLUE,
-    primaryDeep: FORD_BLUE_DEEP,
-    primaryText: "#FFFFFF",
-    primarySoft: "rgba(0, 52, 120, 0.10)",
+    surfaceHover: "#F4F4F6",
+    glassBase: "rgba(255, 255, 255, 0.65)",
+    glassBorder: "rgba(0, 0, 0, 0.06)",
+    border: "rgba(0, 0, 0, 0.08)",
+    borderStrong: "rgba(0, 0, 0, 0.14)",
+    separator: "rgba(0, 0, 0, 0.05)",
+    text: "#1A1A1A",
+    textMuted: "#6B7280",
+    textSubtle: "#9CA3AF",
+    primary: "#1A1A1A",
+    primaryDeep: "#000000",
+    primaryText: "#FAFAFA",
+    primarySoft: "rgba(26, 26, 26, 0.06)",
     success: "#0F8A5F",
     successSoft: "rgba(15, 138, 95, 0.10)",
     warning: "#B5670A",
@@ -68,48 +81,56 @@ export const palette: Record<ThemeMode, ThemeColors> = {
     errorSoft: "rgba(199, 54, 58, 0.10)",
     critical: "#A11A20",
     overlay: "rgba(11, 18, 32, 0.40)",
-    tabBar: "rgba(255, 255, 255, 0.92)",
-    inputBg: "#FFFFFF",
+    tabBar: "rgba(255, 255, 255, 0.78)",
+    inputBg: "rgba(255, 255, 255, 0.60)",
   },
   dark: {
-    bg: "#0B1220",
-    bgElevated: "#101A2E",
-    surface: "#121A2B",
-    surfaceElevated: "#1A2336",
-    surfaceHover: "#1F2A40",
+    bg: "#1E1E1E",
+    bgDeep: "#161616",
+    bgElevated: "#252525",
+    surface: "#252525",
+    surfaceElevated: "#2A2A2A",
+    surfaceHover: "#303030",
+    glassBase: "rgba(40, 40, 40, 0.55)",
+    glassBorder: "rgba(255, 255, 255, 0.08)",
     border: "rgba(255, 255, 255, 0.07)",
     borderStrong: "rgba(255, 255, 255, 0.12)",
-    separator: "rgba(255, 255, 255, 0.05)",
-    text: "#E6EDF7",
-    textMuted: "#93A1B8",
-    textSubtle: "#6C7A95",
-    primary: FORD_BLUE_DARK_MODE,
-    primaryDeep: FORD_BLUE_DARK_MODE_DEEP,
-    primaryText: "#FFFFFF",
-    primarySoft: "rgba(91, 141, 239, 0.16)",
+    separator: "rgba(255, 255, 255, 0.06)",
+    text: "#F5F5F5",
+    textMuted: "#9CA3AF",
+    textSubtle: "#6B7280",
+    primary: "#FAFAFA",
+    primaryDeep: "#E5E5E5",
+    primaryText: "#1A1A1A",
+    primarySoft: "rgba(250, 250, 250, 0.10)",
     success: "#2DB67B",
     successSoft: "rgba(45, 182, 123, 0.16)",
     warning: "#E3A93C",
     warningSoft: "rgba(227, 169, 60, 0.16)",
     error: "#E5484D",
     errorSoft: "rgba(229, 72, 77, 0.16)",
-    critical: "#FF5463",
+    critical: "#FF453A",
     overlay: "rgba(0, 0, 0, 0.6)",
-    tabBar: "rgba(11, 18, 32, 0.85)",
-    inputBg: "#121A2B",
+    tabBar: "rgba(30, 30, 30, 0.72)",
+    inputBg: "rgba(40, 40, 40, 0.55)",
   },
 };
 
+// Font families — Fraunces (display serif) + Inter (sans body) loaded via
+// expo-google-fonts in _layout.tsx. Names below match the package exports.
+// Mono uses system stack (no bundle), with proper Windows fallback.
+// Fontes: Fraunces + Inter via @expo-google-fonts; mono fica em system stack.
 export const fontFamily = {
-  regular: "System",
-  medium: "System",
-  semibold: "System",
-  bold: "System",
-  extrabold: "System",
-  // Web fallback list ordered for legibility on Windows/macOS/Linux: native
-  // monos first, then bundled-with-Windows Cascadia/Consolas. Bare "ui-monospace"
-  // collapsed to a chunky serif on Windows.
-  // Stack ordenada por sistema: Windows nao tem SF Mono, entao precisa de Cascadia/Consolas.
+  // Display serif (Fraunces) — for h-display + h-section.
+  displayRegular: "Fraunces_400Regular",
+  displaySemibold: "Fraunces_600SemiBold",
+  displayBold: "Fraunces_700Bold",
+  // Sans body (Inter) — for body, captions, labels, mono fallback.
+  regular: "Inter_400Regular",
+  medium: "Inter_500Medium",
+  semibold: "Inter_600SemiBold",
+  bold: "Inter_700Bold",
+  // Mono stack (system).
   mono: Platform.select({
     ios: "Menlo",
     android: "monospace",
@@ -118,9 +139,9 @@ export const fontFamily = {
   }) as string,
 } as const;
 
-// Weight tokens — paired with fontFamily.System on RN to get bold variants
-// without bundling custom fonts. When we ship Manrope/Inter later, swap families.
-// Pesos: enquanto nao ha fonte custom, usa system + fontWeight numerico.
+// Numeric weights kept for any caller that still spreads typography helpers.
+// React Native maps these to the loaded font weights automatically when the
+// fontFamily explicitly carries the weight (e.g. Inter_600SemiBold).
 export const fontWeight = {
   regular: "400",
   medium: "500",
@@ -139,8 +160,8 @@ export const fontSize = {
   "2xl": 22,
   "3xl": 28,
   "4xl": 32,
-  "5xl": 48,
-  "6xl": 72,
+  "5xl": 40,
+  "6xl": 56,
 } as const;
 
 export const spacing = {
@@ -176,8 +197,9 @@ export const letterSpacing = {
   ultra: 6,
 } as const;
 
-// Elevation pra light: sombras reais (iOS shadow* + Android elevation).
-// Hierarquia visual depende da luz vinda de cima.
+// Elevation light: real shadows. Elevation dark: subtle top-highlight only
+// (shadows on dark turn into smudges; Vercel/Cursor pattern).
+// Glass surfaces dont use either — they get a thin border via glassBorder.
 export const elevationLight = {
   none: {
     shadowColor: "transparent",
@@ -208,7 +230,7 @@ export const elevationLight = {
     elevation: 4,
   },
   primary: {
-    shadowColor: FORD_BLUE,
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.16,
     shadowRadius: 12,
@@ -216,8 +238,6 @@ export const elevationLight = {
   },
 } as const;
 
-// Elevation pra dark: zero sombra. Hierarquia via top-highlight (borda superior
-// clarinha). Estetica Vercel/Cursor — sombras em fundo escuro viram manchas.
 export const elevationDark = {
   none: {},
   sm: { borderTopColor: "rgba(255,255,255,0.04)", borderTopWidth: 1 },
@@ -226,9 +246,6 @@ export const elevationDark = {
   primary: { borderTopColor: "rgba(255,255,255,0.10)", borderTopWidth: 1 },
 } as const;
 
-// Semantic elevation aliases — usar nas telas em vez de sm/md/lg/primary direto.
-// Card = elemento normal. Sheet = modal/bottom-sheet. Popover = floating action.
-// Aliases semanticos: card / sheet / popover.
 export const elevationAliasLight = {
   card: elevationLight.sm,
   sheet: elevationLight.lg,
@@ -243,27 +260,74 @@ export const elevationAliasDark = {
 
 export type Elevation = typeof elevationLight | typeof elevationDark;
 
-// Typography helpers que combinam size + weight + lineHeight em um objeto
-// pronto pra spread. Substitui o `typography.h1` antigo, agora tema-aware
-// no consumer (cor vem de useTheme()).
-// Helpers de tipografia: spread direto no style.
+// Typography helpers — Fraunces for display, Inter for everything else.
+// Spread directly into a Text style. Color comes from useTheme() at the
+// consumer (these helpers are color-agnostic).
+//
+// Display = page titles, section titles. Heavy serif presence.
+// Body / caption / label = all Inter for UI consistency.
+// Tipografia: Fraunces no display, Inter no resto. Cor vem do consumer.
 export const typography = {
-  h1: {
+  // Display — Fraunces serif.
+  hDisplay: {
+    fontFamily: fontFamily.displayBold,
+    fontSize: fontSize["5xl"],
+    lineHeight: 44,
+    letterSpacing: -1.2,
+  },
+  hSection: {
+    fontFamily: fontFamily.displaySemibold,
     fontSize: fontSize["3xl"],
-    fontWeight: fontWeight.extrabold,
-    lineHeight: 34,
-    letterSpacing: -0.4,
+    lineHeight: 32,
+    letterSpacing: -0.8,
+  },
+  // Legacy aliases (h1/h2) so screens not yet migrated keep working.
+  // Aliases legados pra telas ainda nao migradas.
+  h1: {
+    fontFamily: fontFamily.displayBold,
+    fontSize: fontSize["5xl"],
+    lineHeight: 44,
+    letterSpacing: -1.2,
   },
   h2: {
-    fontSize: fontSize["2xl"],
-    fontWeight: fontWeight.bold,
-    lineHeight: 28,
-    letterSpacing: -0.3,
+    fontFamily: fontFamily.displaySemibold,
+    fontSize: fontSize["3xl"],
+    lineHeight: 32,
+    letterSpacing: -0.8,
   },
-  h3: { fontSize: fontSize.xl, fontWeight: fontWeight.semibold, lineHeight: 24 },
-  body: { fontSize: fontSize.lg, fontWeight: fontWeight.regular, lineHeight: 22 },
-  caption: { fontSize: fontSize.md, fontWeight: fontWeight.regular, lineHeight: 18 },
-  label: { fontSize: fontSize.sm, fontWeight: fontWeight.semibold, letterSpacing: 0.5 },
+  // Body — Inter sans.
+  h3: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.xl,
+    lineHeight: 24,
+  },
+  bodyLg: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.lg + 1,
+    lineHeight: 24,
+  },
+  body: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.lg,
+    lineHeight: 22,
+  },
+  caption: {
+    fontFamily: fontFamily.regular,
+    fontSize: fontSize.md,
+    lineHeight: 18,
+  },
+  label: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.sm,
+    letterSpacing: 0.5,
+  },
+  // Mailchimp-style uppercase tag.
+  labelCaps: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.sm,
+    letterSpacing: 1.4,
+    textTransform: "uppercase" as const,
+  },
   mono: {
     fontFamily: fontFamily.mono,
     fontSize: fontSize.lg,
@@ -334,7 +398,6 @@ export const leadStatusPalette: Record<LeadStatusKey, StatusPaletteEntry> = {
   },
 };
 
-// Priority palette: mapeia api Lead.priority. Critical chama atencao maxima.
 export type LeadPriorityKey = "low" | "medium" | "high" | "critical";
 
 export const leadPriorityPalette: Record<LeadPriorityKey, StatusPaletteEntry> = {
@@ -352,19 +415,18 @@ export const leadPriorityPalette: Record<LeadPriorityKey, StatusPaletteEntry> = 
   },
   high: {
     labelKey: "priority.high",
-    color: FORD_BLUE_DARK_MODE,
+    color: "#5B8DEF",
     bg: "rgba(91, 141, 239, 0.16)",
     border: "rgba(91, 141, 239, 0.45)",
   },
   critical: {
     labelKey: "priority.critical",
-    color: "#FF5463",
-    bg: "rgba(255, 84, 99, 0.16)",
-    border: "rgba(255, 84, 99, 0.50)",
+    color: "#FF453A",
+    bg: "rgba(255, 69, 58, 0.16)",
+    border: "rgba(255, 69, 58, 0.50)",
   },
 };
 
-// Churn segment palette: mapeia segment do ChurnScore.
 export type ChurnSegmentKey = "fiel" | "abandono" | "esquecido" | "economico";
 
 export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = {
@@ -376,9 +438,9 @@ export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = 
   },
   abandono: {
     labelKey: "segment.abandono",
-    color: "#FF5463",
-    bg: "rgba(255, 84, 99, 0.14)",
-    border: "rgba(255, 84, 99, 0.40)",
+    color: "#FF453A",
+    bg: "rgba(255, 69, 58, 0.14)",
+    border: "rgba(255, 69, 58, 0.40)",
   },
   esquecido: {
     labelKey: "segment.esquecido",
@@ -394,9 +456,9 @@ export const churnSegmentPalette: Record<ChurnSegmentKey, StatusPaletteEntry> = 
   },
 };
 
-// Tokens legados — mantidos para callers ainda nao migrados. Vao sumir
-// conforme as telas adotam useTheme(). NAO usar em codigo novo.
-// Legacy tokens: nao usar em codigo novo. Migrar para useTheme().
+// Legacy color export — kept so any code path still importing from this module
+// instead of useTheme() does not break. Migrate consumers to useTheme().
+// Tokens legados: nao usar em codigo novo. Migrar para useTheme().
 export const colors = palette.dark;
 export type ColorToken = keyof ThemeColors;
 export type SpacingToken = keyof typeof spacing;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,18 @@
       "name": "forward-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@expo-google-fonts/fraunces": "^0.4.1",
+        "@expo-google-fonts/inter": "^0.4.2",
         "@expo/metro-runtime": "~55.0.9",
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@supabase/supabase-js": "^2.45.0",
         "expo": "^55.0.15",
+        "expo-blur": "~55.0.14",
         "expo-constants": "~55.0.14",
         "expo-haptics": "~55.0.14",
         "expo-image-picker": "~55.0.20",
+        "expo-linear-gradient": "~55.0.14",
         "expo-linking": "~55.0.13",
         "expo-router": "~55.0.12",
         "expo-secure-store": "~55.0.13",
@@ -1424,6 +1428,18 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/@expo-google-fonts/fraunces": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/fraunces/-/fraunces-0.4.1.tgz",
+      "integrity": "sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/inter": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.4.2.tgz",
+      "integrity": "sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/material-symbols": {
       "version": "0.4.31",
@@ -4458,6 +4474,17 @@
         }
       }
     },
+    "node_modules/expo-blur": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-55.0.14.tgz",
+      "integrity": "sha512-NKyCKFWTNpX4CZSsiE1sgkqk/yvR1K0UTukuIbxVKoobB+yALLg1CFav0NqfdQqjhtoj5oEzP0Brlq92Z08Zfg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "55.0.14",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.14.tgz",
@@ -4545,6 +4572,17 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-55.0.14.tgz",
+      "integrity": "sha512-n01A9P0ZebRo8Rm4QHYEjMR8z4Y6MBc8uVnT8NB9cOJislvEmz2o2WQJoK6RD7FjoeFEW8KkRtggK7fQ3h7KIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@expo-google-fonts/fraunces": "^0.4.1",
+    "@expo-google-fonts/inter": "^0.4.2",
     "@expo/metro-runtime": "~55.0.9",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@supabase/supabase-js": "^2.45.0",
     "expo": "^55.0.15",
+    "expo-blur": "~55.0.14",
     "expo-constants": "~55.0.14",
     "expo-haptics": "~55.0.14",
     "expo-image-picker": "~55.0.20",
+    "expo-linear-gradient": "~55.0.14",
     "expo-linking": "~55.0.13",
     "expo-router": "~55.0.12",
     "expo-secure-store": "~55.0.13",


### PR DESCRIPTION
## Summary

Tela final da Fase 2. Stacked sobre [#39 (Lead detail)](https://github.com/fwd-ford/forward-mobile/pull/39).

- Tab bar agora **flutua** (\`position: absolute\` + bg transparent) — conteudo desliza atras
- \`tabBarBackground\` renderiza \`GlassSurface variant=\"thick\"\` com hairline \`glassBorder\` superior
- Active tint: \`c.primary\` -> \`c.text\` (Ford Blue saiu, branco/preto dependendo do tema)
- Icon -2px + label Inter SemiBold 11 com tracking leve (Mailchimp/Shopify tight)
- Padding bottom das telas (\`spacing.6xl\`) ja cobre a barra flutuante, zero ajuste por tela

Fim da Fase 2. Proxima: Fase 3 — extrair componentes (\`ScreenTitle\`, \`GlassCard\`, \`PillButton\`, \`UnderlineInput\`) depois que voce aprovar visualmente.

## Test plan
- [x] \`npx tsc --noEmit\` zero erros
- [ ] Manual: tab bar com blur visivel, conteudo passa por baixo
- [ ] Manual: trocar tab — icone outline -> filled, label muda de cor
- [ ] Manual: light + dark — bar adapta o glass + tint

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>