### PR TITLE
feat(design): Tab bar Glass floating + dark/animation fixes [Fase 2, 6/6]

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     "userInterfaceStyle": "automatic",
     "splash": {
       "resizeMode": "contain",
-      "backgroundColor": "#0B1220"
+      "backgroundColor": "#1E1E1E"
     },
     "assetBundlePatterns": [
       "**/*"
@@ -20,7 +20,7 @@
     "android": {
       "package": "com.fwdford.forwardservice",
       "adaptiveIcon": {
-        "backgroundColor": "#0B1220"
+        "backgroundColor": "#1E1E1E"
       }
     },
     "web": {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -56,6 +56,10 @@ export default function TabsLayout() {
         // default; without this the mesh background gets covered inside tabs.
         // sceneStyle no v7 substituiu sceneContainerStyle do v6.
         sceneStyle: { backgroundColor: "transparent" },
+        // animation 'none' avoids the visible overlap when both scenes are
+        // transparent and the cross-fade momentarily renders both stacked.
+        // Sem isso, a troca de aba mostra ambas as cenas sobrepostas.
+        animation: "none",
         tabBarStyle: {
           position: "absolute",
           left: 0,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -52,6 +52,10 @@ export default function TabsLayout() {
     <Tabs
       screenOptions={{
         headerShown: false,
+        // react-navigation/bottom-tabs v7 paints the scene container white by
+        // default; without this the mesh background gets covered inside tabs.
+        // sceneStyle no v7 substituiu sceneContainerStyle do v6.
+        sceneStyle: { backgroundColor: "transparent" },
         tabBarStyle: {
           position: "absolute",
           left: 0,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,10 +1,19 @@
+// Tab bar — Glass Minimalist redesign (Fase 2, screen 6/6).
+// Bar is absolute-positioned and uses GlassSurface variant="thick" as the
+// background; expo-router renders the labels/icons on top. Active tint moves
+// from primary (was Ford Blue) to text token so it reads in both modes.
+//
+// Tab bar glass thick flutuando sobre conteudo (estilo iOS).
+
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
 import { useCallback } from "react";
 import { StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
 
+import { GlassSurface } from "@/components/ui/GlassSurface";
 import { useTheme } from "@/context/ThemeContext";
+import { fontFamily } from "@/lib/theme";
 
 type TabIconKey = "index" | "leads" | "profile";
 
@@ -32,7 +41,7 @@ export default function TabsLayout() {
       ({ color, size, focused }: TabIconRenderProps) => (
         <Ionicons
           name={focused ? ICONS[key].focused : ICONS[key].unfocused}
-          size={size}
+          size={size - 2}
           color={color}
         />
       ),
@@ -44,13 +53,37 @@ export default function TabsLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: {
-          backgroundColor: colors.tabBar,
-          borderTopColor: colors.separator,
-          borderTopWidth: StyleSheet.hairlineWidth,
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: "transparent",
+          borderTopWidth: 0,
+          elevation: 0,
         },
-        tabBarActiveTintColor: colors.primary,
+        // Hairline divider on top so the glass tab bar reads as detached, not
+        // floating ambiguously over content. tabBarBackground owns the blur.
+        tabBarBackground: () => (
+          <GlassSurface
+            variant="thick"
+            radius={0}
+            border={false}
+            style={[
+              StyleSheet.absoluteFillObject,
+              {
+                borderTopWidth: StyleSheet.hairlineWidth,
+                borderTopColor: colors.glassBorder,
+              },
+            ]}
+          />
+        ),
+        tabBarActiveTintColor: colors.text,
         tabBarInactiveTintColor: colors.textMuted,
-        tabBarLabelStyle: { fontSize: 12, fontWeight: "600" },
+        tabBarLabelStyle: {
+          fontFamily: fontFamily.semibold,
+          fontSize: 11,
+          letterSpacing: 0.2,
+        },
       }}
     >
       <Tabs.Screen

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -71,7 +71,11 @@ function RootStack() {
   useGuardedRedirect(ready && introDone && themeHydrated, session);
 
   return (
-    <View style={styles.root}>
+    // Solid bg colors.bg before the mesh paints — without this, the system
+    // fallback (white on web, sometimes on RN-screens) flashes through if the
+    // mesh layer is delayed by a frame. Mesh + glass surfaces still render on top.
+    // Bg solido como rede de seguranca; sem isso, branco do sistema pisca.
+    <View style={[styles.root, { backgroundColor: colors.bg }]}>
       <StatusBar style={mode === "dark" ? "light" : "dark"} />
       {/* Mesh sits behind every route so glass surfaces have texture to blur. */}
       {/* Mesh fica atras de tudo pra o glass ter algo pra borrar. */}

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -50,7 +50,15 @@ function isThemeMode(value: string | null): value is ThemeMode {
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const systemScheme = useColorScheme();
-  const systemMode: ThemeMode = systemScheme === "light" ? "light" : "dark";
+  // Glass Minimalist design ships dark as the canonical mode. Users can opt
+  // into light via the Profile switch. Following the system would surprise
+  // anyone whose OS is in light by hiding the design's signature look, and
+  // react-native-web's useColorScheme misfires on Windows browsers.
+  // Default dark sempre; light eh opt-in via switch.
+  const systemMode: ThemeMode = "dark";
+  // Unused — kept on purpose so we can revisit follow-system if the product
+  // decides to honor it later. Avoids a noisy refactor when re-enabled.
+  void systemScheme;
 
   // override === null means "follow system"; otherwise it pins the mode.
   const [override, setOverride] = useState<ThemeMode | null>(null);


### PR DESCRIPTION
Recreated. Tab bar absolute glass thick (iOS-style floating) + default dark + animation none. Spec: docs/superpowers/specs/2026-05-23-glass-minimalist-design.md.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>