### PR TITLE
fix(design): dark default for real + tabs overlap

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -60,6 +60,15 @@ export default function TabsLayout() {
         // transparent and the cross-fade momentarily renders both stacked.
         // Sem isso, a troca de aba mostra ambas as cenas sobrepostas.
         animation: "none",
+        // freezeOnBlur + lazy: react-navigation v7 keeps inactive scenes
+        // mounted by default. With transparent sceneStyle both render at once
+        // visually. freezeOnBlur pauses inactive scenes, lazy delays the first
+        // render of unfocused tabs until they get touched. Together they keep
+        // the swap clean without ghost layers.
+        // Sem isso, cenas inativas ficam visiveis sobrepostas; lazy/freeze
+        // garantem que so a ativa pinta.
+        freezeOnBlur: true,
+        lazy: true,
         tabBarStyle: {
           position: "absolute",
           left: 0,

--- a/lib/storage-keys.ts
+++ b/lib/storage-keys.ts
@@ -3,7 +3,11 @@
 // Chaves de storage centralizadas; proibido usar string literal nos consumers.
 
 export const STORAGE_KEYS = {
-  THEME: "@forward:theme",
+  // Bumped to v2 when the design system shipped Glass Minimalist with dark as
+  // the canonical default. Old @forward:theme values (potentially "light" from
+  // the previous follow-system behavior) would otherwise hijack the new boot.
+  // Key bumpada pra invalidar overrides antigos quando dark virou default.
+  THEME: "@forward:theme_v2",
   LOCALE: "@forward:locale",
   ONBOARDED: "@forward:onboarded",
   CURRENT_DEALER_ID: "@forward:current_dealer_id",


### PR DESCRIPTION
Root causes:

**Bug 1+2 (dark flash, fake animation):** AsyncStorage tinha `@forward:theme="light"` salvo de quando ThemeContext seguia o sistema. Boot hidratava esse valor APOS o primeiro render em dark, causando flash dark->light que pareceu animacao errada. Fix: bump key pra `@forward:theme_v2` — sessoes existentes nao tem valor, override fica null, mode lock em dark sem flash.

**Bug 3 (abas sobrepostas):** react-navigation v7 mantem scenes inativas montadas. Com `sceneStyle: transparent`, ambas pintavam durante a troca. `animation: 'none'` sozinho nao resolveu porque o problema e ciclo de render, nao animacao. Adicionado `freezeOnBlur: true` (pausa cenas inativas) + `lazy: true` (delay primeiro render). Agora so a ativa pinta.

## Test plan
- [x] tsc zero erros
- [ ] Manual: hard refresh do web — app abre dark, fica dark, sem flash
- [ ] Manual: trocar aba — sem sobreposicao visual, troca instantanea

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>