### PR TITLE
fix(lead-detail): 3 P0s — header overlap, wrong eyebrow, URL leaking lead JSON

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -219,7 +219,7 @@ export default function HomeScreen() {
             onPress={() =>
               router.push({
                 pathname: "/lead/[id]",
-                params: { id: item.id, lead: JSON.stringify(item) },
+                params: { id: item.id },
               })
             }
           />

--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -294,7 +294,7 @@ export default function LeadsScreen() {
                 onPress={() =>
                   router.push({
                     pathname: "/lead/[id]",
-                    params: { id: item.id, lead: JSON.stringify(item) },
+                    params: { id: item.id },
                   })
                 }
               />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -107,7 +107,7 @@ function RootStack() {
         >
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="login" options={{ title: "" }} />
-          <Stack.Screen name="lead/[id]" options={{ title: "Lead" }} />
+          <Stack.Screen name="lead/[id]" options={{ headerShown: false }} />
         </Stack>
       )}
     </View>

--- a/app/lead/[id].tsx
+++ b/app/lead/[id].tsx
@@ -1,5 +1,5 @@
 // Lead detail — Glass Minimalist redesign (Fase 2, screen 5/6).
-// Header: labelCaps "LEAD" + VIN mono large + priority/status badges.
+// Header: own back pill (no Stack header) + VIN eyebrow + VIN mono large + badges.
 // Body: glass sections for reason and value.
 // Footer: glass thick fixed at the bottom with 3 actions.
 
@@ -13,6 +13,7 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 
@@ -36,30 +37,19 @@ import {
   type ThemeColors,
 } from "@/lib/theme";
 
-function tryParseLead(serialized: string | string[] | undefined): Lead | null {
-  if (!serialized || Array.isArray(serialized)) return null;
-  try {
-    const parsed = JSON.parse(serialized) as Lead;
-    return parsed && typeof parsed.id === "string" ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
 export default function LeadDetailScreen() {
-  const { id, lead: serializedLead } = useLocalSearchParams<{ id: string; lead?: string }>();
+  // Solo o id na URL. O JSON serializado costumava vir aqui para hidratacao
+  // instantanea, mas vazava customer_id/dealer_id na URL do browser e no
+  // historico. Trocamos por sempre carregar via load() — Sprint 1 ainda
+  // pega via listLeads(); quando o backend expuser GET /leads/{id}, trocar.
+  const { id } = useLocalSearchParams<{ id: string }>();
   const { t } = useTranslation();
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
-  // Hidrata na hora se a tela anterior passou o lead serializado (caminho feliz
-  // vindo de Home/Leads). Cai pro listLeads quando o usuario abre por deep link
-  // sem param, ou quando a desserializacao falha.
-  const hydratedLead = useMemo(() => tryParseLead(serializedLead), [serializedLead]);
-
-  const [lead, setLead] = useState<Lead | null>(hydratedLead);
-  const [loading, setLoading] = useState(hydratedLead === null);
+  const [lead, setLead] = useState<Lead | null>(null);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [footerHeight, setFooterHeight] = useState(0);
   const [toast, setToast] = useState<{
@@ -84,9 +74,8 @@ export default function LeadDetailScreen() {
   }, [id, t]);
 
   useEffect(() => {
-    if (hydratedLead && hydratedLead.id === id) return;
     void load();
-  }, [hydratedLead, id, load]);
+  }, [load]);
 
   const onComingSoonAction = useCallback(
     (actionKey: string) => {
@@ -104,10 +93,30 @@ export default function LeadDetailScreen() {
     setFooterHeight(e.nativeEvent.layout.height);
   }, []);
 
+  // Back pill rendered floating top-left; appears in every state so a stuck
+  // skeleton or error screen still has a way out.
+  // Pill flutuante de voltar — presente em loading/error/empty/ok pra nao
+  // prender o usuario.
+  const BackPill = (
+    <Pressable
+      onPress={() => router.back()}
+      hitSlop={8}
+      style={({ pressed }) => [
+        styles.backPillFloat,
+        { top: insets.top + spacing.md },
+        pressed && { opacity: 0.85, transform: [{ scale: 0.97 }] },
+      ]}
+    >
+      <Ionicons name="chevron-back" size={18} color={colors.text} />
+      <Text style={styles.backPillFloatLabel}>{t("common.back")}</Text>
+    </Pressable>
+  );
+
   if (loading && !lead) {
     return (
-      <View style={[styles.container, { paddingTop: insets.top + spacing["3xl"] }]}>
-        <View style={styles.scroll}>
+      <View style={styles.container}>
+        {BackPill}
+        <View style={[styles.scroll, { paddingTop: insets.top + spacing["4xl"] }]}>
           <Skeleton width={120} height={14} borderRadius={radius.sm} />
           <Skeleton width={240} height={32} borderRadius={radius.sm} />
           <View style={styles.skeletonRow}>
@@ -123,20 +132,10 @@ export default function LeadDetailScreen() {
 
   if (error) {
     return (
-      <View style={[styles.container, { paddingTop: insets.top + spacing["3xl"] }]}>
-        <View style={styles.errorWrap}>
+      <View style={styles.container}>
+        {BackPill}
+        <View style={[styles.errorWrap, { paddingTop: insets.top + spacing["4xl"] }]}>
           <ErrorBanner message={error} onRetry={() => void load()} />
-        </View>
-        <View style={styles.notFoundActions}>
-          <Pressable
-            onPress={() => router.back()}
-            style={({ pressed }) => [
-              styles.backPill,
-              pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
-            ]}
-          >
-            <Text style={styles.backPillLabel}>{t("common.back")}</Text>
-          </Pressable>
         </View>
       </View>
     );
@@ -144,17 +143,11 @@ export default function LeadDetailScreen() {
 
   if (!lead) {
     return (
-      <View style={[styles.center, { paddingTop: insets.top }]}>
-        <Text style={styles.muted}>{t("lead.not_found")}</Text>
-        <Pressable
-          onPress={() => router.back()}
-          style={({ pressed }) => [
-            styles.backPillPrimary,
-            pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
-          ]}
-        >
-          <Text style={styles.backPillPrimaryLabel}>{t("common.back")}</Text>
-        </Pressable>
+      <View style={styles.container}>
+        {BackPill}
+        <View style={[styles.center, { paddingTop: insets.top }]}>
+          <Text style={styles.muted}>{t("lead.not_found")}</Text>
+        </View>
       </View>
     );
   }
@@ -165,17 +158,18 @@ export default function LeadDetailScreen() {
 
   return (
     <View style={styles.container}>
+      {BackPill}
       <ScrollView
         contentContainerStyle={[
           styles.scroll,
           {
-            paddingTop: insets.top + spacing["3xl"],
+            paddingTop: insets.top + spacing["4xl"],
             paddingBottom: insets.bottom + footerHeight + spacing.lg,
           },
         ]}
         showsVerticalScrollIndicator={false}
       >
-        <Text style={styles.labelCaps}>{t("lead.priority")}</Text>
+        <Text style={styles.labelCaps}>{t("lead.vin_label")}</Text>
         <Text style={styles.vin} numberOfLines={1}>
           {lead.vin ?? "—"}
         </Text>
@@ -271,6 +265,25 @@ function createStyles(c: ThemeColors) {
       paddingHorizontal: spacing["2xl"],
       gap: spacing.md,
     },
+    backPillFloat: {
+      position: "absolute",
+      left: spacing.lg,
+      zIndex: 10,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.xs,
+      paddingVertical: spacing.xs + 2,
+      paddingHorizontal: spacing.md,
+      borderRadius: radius.pill,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: c.borderStrong,
+      backgroundColor: c.surface,
+    },
+    backPillFloatLabel: {
+      ...typography.label,
+      fontFamily: fontFamily.semibold,
+      color: c.text,
+    },
     labelCaps: {
       ...typography.labelCaps,
       color: c.textMuted,
@@ -343,34 +356,6 @@ function createStyles(c: ThemeColors) {
       justifyContent: "center",
       padding: spacing.xl,
       gap: spacing.lg,
-    },
-    notFoundActions: {
-      marginTop: spacing.lg,
-      paddingHorizontal: spacing["2xl"],
-    },
-    backPill: {
-      alignSelf: "flex-start",
-      paddingVertical: spacing.md,
-      paddingHorizontal: spacing["2xl"],
-      borderRadius: radius.pill,
-      borderWidth: StyleSheet.hairlineWidth,
-      borderColor: c.borderStrong,
-    },
-    backPillLabel: {
-      ...typography.body,
-      fontFamily: fontFamily.semibold,
-      color: c.text,
-    },
-    backPillPrimary: {
-      paddingVertical: spacing.md,
-      paddingHorizontal: spacing["3xl"],
-      borderRadius: radius.pill,
-      backgroundColor: c.primary,
-    },
-    backPillPrimaryLabel: {
-      ...typography.body,
-      fontFamily: fontFamily.semibold,
-      color: c.primaryText,
     },
   });
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -54,6 +54,7 @@
     "required": "Required field"
   },
   "lead": {
+    "vin_label": "VIN",
     "priority": "Priority",
     "status": "Status",
     "reason": "Reason",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -58,6 +58,7 @@
     "required": "Campo obrigatório"
   },
   "lead": {
+    "vin_label": "VIN",
     "priority": "Prioridade",
     "status": "Status",
     "reason": "Motivo",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -18,12 +18,12 @@
     "subtitle": "Bem-vindo. Entre para acessar seus leads.",
     "loading": "Carregando",
     "signing_in": "Entrando...",
-    "error": "Nao foi possivel entrar. Verifique suas credenciais.",
+    "error": "Não foi possível entrar. Verifique suas credenciais.",
     "forgot_password": "Esqueci minha senha",
-    "forgot_help": "Em breve. Por enquanto, peca um reset ao seu admin."
+    "forgot_help": "Em breve. Por enquanto, peça um reset ao seu admin."
   },
   "tabs": {
-    "home": "Inicio",
+    "home": "Início",
     "leads": "Leads",
     "schedule": "Agenda",
     "profile": "Perfil"
@@ -36,9 +36,9 @@
     "todays_leads": "Leads de hoje",
     "empty": "Nenhum lead no momento",
     "empty_title": "Sem leads por enquanto",
-    "empty_description": "Quando novos leads forem atribuidos a voce, eles aparecem aqui.",
+    "empty_description": "Quando novos leads forem atribuídos a você, eles aparecem aqui.",
     "error": "Falha ao carregar dados",
-    "error_title": "Sem conexao com o servidor",
+    "error_title": "Sem conexão com o servidor",
     "hero": {
       "active_leads": "Leads ativos",
       "pipeline": "Pipeline"
@@ -50,12 +50,12 @@
   },
   "validation": {
     "email_required": "Informe seu e-mail",
-    "email_invalid": "E-mail invalido",
+    "email_invalid": "E-mail inválido",
     "password_required": "Informe sua senha",
     "password_too_short": "Senha precisa de pelo menos {{count}} caracteres",
     "name_required": "Informe seu nome",
     "name_short": "Nome muito curto",
-    "required": "Campo obrigatorio"
+    "required": "Campo obrigatório"
   },
   "lead": {
     "priority": "Prioridade",
@@ -97,17 +97,17 @@
     "fiel": "Fiel",
     "abandono": "Abandono",
     "esquecido": "Esquecido",
-    "economico": "Economico"
+    "economico": "Econômico"
   },
   "priority": {
     "low": "Baixa",
-    "medium": "Media",
+    "medium": "Média",
     "high": "Alta",
-    "critical": "Critica"
+    "critical": "Crítica"
   },
   "status": {
     "new": "Novo",
-    "assigned": "Atribuido",
+    "assigned": "Atribuído",
     "contacted": "Contatado",
     "converted": "Convertido",
     "lost": "Perdido",
@@ -117,7 +117,7 @@
     "sign_out": "Sair",
     "unnamed": "Sem nome",
     "account": "Conta",
-    "appearance": "Aparencia",
+    "appearance": "Aparência",
     "dark_mode": "Modo escuro",
     "light_mode": "Modo claro",
     "theme_auto": "Seguindo o sistema",
@@ -126,13 +126,13 @@
     "language": "Idioma",
     "photo": "Foto",
     "change_photo": "Trocar foto",
-    "camera": "Camera",
+    "camera": "Câmera",
     "gallery": "Galeria",
     "remove": "Remover",
     "photo_updated": "Foto atualizada",
-    "photo_failed": "Nao foi possivel enviar a foto",
+    "photo_failed": "Não foi possível enviar a foto",
     "photo_removed": "Foto removida",
-    "photo_remove_failed": "Nao foi possivel remover a foto"
+    "photo_remove_failed": "Não foi possível remover a foto"
   },
   "cta": {
     "close": "Fechar",


### PR DESCRIPTION
## Resumo

QA round 2 (24/05) flagou 3 P0 issues no Lead Detail. Este PR ataca os três juntos porque entrelaçam (todos mexem em `app/lead/[id].tsx`).

## Stacked branch

Base em [#49](https://github.com/fwd-ford/forward-mobile/pull/49) (acentos PT-BR), que está em [#48](https://github.com/fwd-ford/forward-mobile/pull/48) (wip-rescue). Mergear em ordem: #48 → #49 → este. Posso rebaseio depois se preferir.

## P0-1 · Header sobreposto

**Antes:** Stack header default (`title: "Lead"` + back arrow nativo) cobria o eyebrow do conteúdo mesmo com `paddingTop = insets.top + 3xl`, porque o header consome mais espaço que esse offset reservava.

**Depois:** `headerShown: false` no `Stack.Screen "lead/[id]"`, e back pill próprio absolutely positioned no topo esquerdo (chevron + "Voltar"). Aparece em todos os estados (loading/error/empty/ok) pra nunca prender o usuário.

Bonus: remove header redundante "Lead" que duplicava o conteúdo do hero.

## P0-3 · Eyebrow errado

**Antes:** label era `Prioridade` (`lead.priority`) mas o texto grande abaixo é a VIN. Semanticamente incorreto.

**Depois:** nova key `lead.vin_label: "VIN"` em pt-BR e en. Priority continua nas badges abaixo (correto).

## P0-4 · URL vazava JSON inteiro do lead

**Antes:** Home + Leads faziam:
```ts
router.push({ pathname: '/lead/[id]', params: { id: item.id, lead: JSON.stringify(item) } });
```
No web isso virava `?lead=<URL-encoded-JSON>` na URL, vazando `customer_id`, `dealer_id` e valores no histórico do browser.

**Depois:** callers passam só `{ id }`. Lead Detail dropa `serializedLead/hydratedLead/tryParseLead` e sempre carrega via `load()` no mount.

- Custo: skeleton brevemente (~few hundred ms) ao abrir.
- Ganho: privacidade, URL limpa, deep-link funcional.
- Quando Phase 6 (TanStack Query) chegar, cache resolve o skeleton.

## Verificação

- `npx tsc --noEmit`: pass
- Playwright: clicar num lead → URL = `/lead/{id}` (sem `?lead=`); eyebrow "VIN"; back pill funciona; sem header overlap. Screenshot anexo: `v3-01-lead-detail-fixed.png`.

## Não atacado nesta PR (fica pra próximas)

- **P0-2 ações "EM BREVE"**: Ligar/Mensagem/Marcar contato — ao menos Ligar via `tel:` link pode rodar sem backend.
- **P0-5 falta info de cliente/veículo**: depende de backend expor `GET /lead/{id}` com customer + vehicle joined.
- **P0-6 reason "Auto-generated from churn score v0.1"**: copy de debug do modelo ML, fica para PR backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
