### PR TITLE
fix(i18n): corrigir 11 chaves de pt-BR sem acento

### DIFF
--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -18,12 +18,12 @@
     "subtitle": "Bem-vindo. Entre para acessar seus leads.",
     "loading": "Carregando",
     "signing_in": "Entrando...",
-    "error": "Nao foi possivel entrar. Verifique suas credenciais.",
+    "error": "Não foi possível entrar. Verifique suas credenciais.",
     "forgot_password": "Esqueci minha senha",
-    "forgot_help": "Em breve. Por enquanto, peca um reset ao seu admin."
+    "forgot_help": "Em breve. Por enquanto, peça um reset ao seu admin."
   },
   "tabs": {
-    "home": "Inicio",
+    "home": "Início",
     "leads": "Leads",
     "schedule": "Agenda",
     "profile": "Perfil"
@@ -36,9 +36,9 @@
     "todays_leads": "Leads de hoje",
     "empty": "Nenhum lead no momento",
     "empty_title": "Sem leads por enquanto",
-    "empty_description": "Quando novos leads forem atribuidos a voce, eles aparecem aqui.",
+    "empty_description": "Quando novos leads forem atribuídos a você, eles aparecem aqui.",
     "error": "Falha ao carregar dados",
-    "error_title": "Sem conexao com o servidor",
+    "error_title": "Sem conexão com o servidor",
     "hero": {
       "active_leads": "Leads ativos",
       "pipeline": "Pipeline"
@@ -50,12 +50,12 @@
   },
   "validation": {
     "email_required": "Informe seu e-mail",
-    "email_invalid": "E-mail invalido",
+    "email_invalid": "E-mail inválido",
     "password_required": "Informe sua senha",
     "password_too_short": "Senha precisa de pelo menos {{count}} caracteres",
     "name_required": "Informe seu nome",
     "name_short": "Nome muito curto",
-    "required": "Campo obrigatorio"
+    "required": "Campo obrigatório"
   },
   "lead": {
     "priority": "Prioridade",
@@ -97,17 +97,17 @@
     "fiel": "Fiel",
     "abandono": "Abandono",
     "esquecido": "Esquecido",
-    "economico": "Economico"
+    "economico": "Econômico"
   },
   "priority": {
     "low": "Baixa",
-    "medium": "Media",
+    "medium": "Média",
     "high": "Alta",
-    "critical": "Critica"
+    "critical": "Crítica"
   },
   "status": {
     "new": "Novo",
-    "assigned": "Atribuido",
+    "assigned": "Atribuído",
     "contacted": "Contatado",
     "converted": "Convertido",
     "lost": "Perdido",
@@ -117,7 +117,7 @@
     "sign_out": "Sair",
     "unnamed": "Sem nome",
     "account": "Conta",
-    "appearance": "Aparencia",
+    "appearance": "Aparência",
     "dark_mode": "Modo escuro",
     "light_mode": "Modo claro",
     "theme_auto": "Seguindo o sistema",
@@ -126,13 +126,13 @@
     "language": "Idioma",
     "photo": "Foto",
     "change_photo": "Trocar foto",
-    "camera": "Camera",
+    "camera": "Câmera",
     "gallery": "Galeria",
     "remove": "Remover",
     "photo_updated": "Foto atualizada",
-    "photo_failed": "Nao foi possivel enviar a foto",
+    "photo_failed": "Não foi possível enviar a foto",
     "photo_removed": "Foto removida",
-    "photo_remove_failed": "Nao foi possivel remover a foto"
+    "photo_remove_failed": "Não foi possível remover a foto"
   },
   "cta": {
     "close": "Fechar",


### PR DESCRIPTION
## Resumo

Re-abertura do antigo #49 que fechou junto com a base `chore/wip-rescue-2026-05-24` (deletada na merge do #48). Conteúdo idêntico — rebaseado sobre main.

Catalogado durante QA round 2 (24/05, porta 8081 com API conectada): `i18n/pt-BR.json` tinha **11 chaves sem acentuação misturadas com chaves corretas** (`Críticos` com acento e `Critica` sem, `Lead não encontrado` com til e `Sem conexao` sem). Inconsistência interna sinaliza falta de revisão final.

## Chaves corrigidas

| Chave | Antes | Depois |
| --- | --- | --- |
| `auth.error` | Nao foi possivel entrar... | Não foi possível entrar... |
| `auth.forgot_help` | peca um reset | peça um reset |
| `tabs.home` | Inicio | Início |
| `home.empty_description` | atribuidos a voce | atribuídos a você |
| `home.error_title` | Sem conexao com o servidor | Sem conexão com o servidor |
| `validation.email_invalid` | E-mail invalido | E-mail inválido |
| `validation.required` | Campo obrigatorio | Campo obrigatório |
| `segment.economico` | Economico | Econômico |
| `priority.medium` | Media | Média |
| `priority.critical` | Critica | Crítica |
| `status.assigned` | Atribuido | Atribuído |
| `profile.appearance` | Aparencia | Aparência |
| `profile.camera` | Camera | Câmera |
| `profile.photo_failed` / `photo_remove_failed` | Nao foi possivel ... | Não foi possível ... |

## Mantido sem alteração

- `auth.email_placeholder` `voce@empresa.com` — e-mail, sem acento mesmo. Troca para exemplo idiomático fica para PR de copy separado.
- `profile.theme_manual` `Override manual ativo` — jargão técnico (P1-9 do QA round 2), fica para outro PR.

## Verificação

- JSON parses OK (`ConvertFrom-Json`)
- Diff: 15 insertions / 15 deletions (só encoding mudou)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
