### PR TITLE
feat(leads): contagem por filtro nos chips

### DIFF
--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -130,6 +130,17 @@ export default function LeadsScreen() {
     () => leads.filter((l) => ACTIVE_LEAD_STATUSES.has(l.status)).length,
     [leads],
   );
+  // Counts per filter ANTES do search query — chips mostram o universo
+  // disponivel, search filtra em cima do filter ativo.
+  const filterCounts = useMemo(
+    () => ({
+      all: applyFilters(leads, "all", "").length,
+      critical: applyFilters(leads, "critical", "").length,
+      today: applyFilters(leads, "today", "").length,
+      forgotten: applyFilters(leads, "forgotten", "").length,
+    }),
+    [leads],
+  );
   const isFiltering = filter !== "all" || query.trim().length > 0;
   // Mirror Home: when fetch fails with no cached data, swap the search+chips
   // header + ErrorBanner combo for a full-screen EmptyState + retry pill so
@@ -218,6 +229,17 @@ export default function LeadsScreen() {
                         ]}
                       >
                         {t(f.labelKey)}
+                        {filterCounts[f.key] > 0 ? (
+                          <Text
+                            style={[
+                              styles.chipCount,
+                              { color: active ? colors.primaryText : colors.textMuted },
+                            ]}
+                          >
+                            {"  "}
+                            {filterCounts[f.key]}
+                          </Text>
+                        ) : null}
                       </Text>
                     </Wrapper>
                   </Pressable>
@@ -348,6 +370,11 @@ function createStyles(c: ThemeColors) {
     chipActive: {
       backgroundColor: c.primary,
       borderWidth: 0,
+    },
+    chipCount: {
+      ...typography.label,
+      fontFamily: fontFamily.semibold,
+      opacity: 0.8,
     },
     chipLabel: {
       ...typography.caption,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -87,7 +87,7 @@
       "all": "All",
       "critical": "Critical",
       "today": "Today",
-      "forgotten": "Forgotten 30d+"
+      "forgotten": "Forgotten"
     },
     "empty_search_title": "Nothing found",
     "empty_search_description": "No leads for '{{query}}'. Try a partial VIN or another filter."

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -91,7 +91,7 @@
       "all": "Todos",
       "critical": "Críticos",
       "today": "Hoje",
-      "forgotten": "Esquecidos 30d+"
+      "forgotten": "Esquecidos"
     },
     "empty_search_title": "Nada encontrado",
     "empty_search_description": "Sem leads para '{{query}}'. Tente VIN parcial ou outro filtro."


### PR DESCRIPTION
## Resumo

Vendedor escolhe o filtro sem precisar tocar pra descobrir o que tem. Antes, ele clicava em "Críticos" pra ver se vale a pena. Agora já lê `Críticos 3` antes de tocar.

## Mudanças

- `filterCounts` `useMemo` calcula a contagem de cada filter (`all`, `critical`, `today`, `forgotten`) sobre o array completo, **antes do search query** — chips refletem o universo disponível; search filtra em cima do filter ativo.
- Chip renderiza `{label}  {count}` quando `count > 0`. Quando `0`, esconde o count (evita `Hoje 0` deprimente em early morning).
- count usa `Text` aninhado com cor `textMuted` (ou `primaryText` no chip ativo), opacity 0.8 — diferencia visualmente sem competir com a label.

## Bonus: i18n

Label `leads.filter.forgotten` `"Esquecidos 30d+"` / `"Forgotten 30d+"` encurtado pra `"Esquecidos"` / `"Forgotten"`. O `30d+` era detalhe de implementação; usuário não precisa do limiar exato na pill (o nome "esquecido" já transmite o conceito). Também ajuda a caber no viewport mobile junto com o count.

## Antes / Depois

| Filter | Antes | Depois (com 3 leads críticos) |
| --- | --- | --- |
| All | `Todos` | `Todos  N` |
| Critical | `Críticos` | `Críticos  3` |
| Today | `Hoje` | `Hoje  N` (ou só `Hoje` se 0) |
| Forgotten | `Esquecidos 30d+` | `Esquecidos  N` (ou só `Esquecidos` se 0) |

## Verificação

- `npx tsc --noEmit`: pass
- Lógica do `filterCounts` reaproveita `applyFilters(leads, key, "")` — passa query vazia pra contar só o filter sem o search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
