### PR TITLE
fix(mobile): polish round 2 P2s (mesh + profile + lead-detail + dates)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -173,7 +173,7 @@ export default function HomeScreen() {
               <LeadCardSkeleton />
             </View>
           ) : !initialLoading && topLeads.length > 0 ? (
-            <Text style={styles.sectionTitle}>{t("home.todays_leads")}</Text>
+            <Text style={styles.sectionTitle}>{t("home.recent_leads")}</Text>
           ) : null}
         </View>
       }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -260,7 +260,8 @@ export default function ProfileScreen() {
           ) : null}
         </GlassSurface>
 
-        {/* Idioma */}
+        {/* Idioma — section header "IDIOMA" + row mostra o idioma SELECIONADO
+            como label (em vez de duplicar "Idioma"). Value vira o short code. */}
         <Text style={styles.sectionLabel}>{t("profile.language")}</Text>
         <GlassSurface variant="thin" radius={20} style={styles.sectionGroup}>
           <Pressable
@@ -271,8 +272,9 @@ export default function ProfileScreen() {
           >
             <SettingRow
               icon="globe-outline"
-              label={t("profile.language")}
-              value={`${LOCALE_LABEL[locale]} · ${LOCALE_SHORT[locale]}`}
+              label={LOCALE_LABEL[locale]}
+              value={LOCALE_SHORT[locale]}
+              emphasis="label"
               right={<Ionicons name="chevron-down" size={16} color={colors.textSubtle} />}
             />
           </Pressable>
@@ -389,7 +391,9 @@ function createStyles(c: ThemeColors) {
     signOutLabel: {
       ...typography.body,
       fontFamily: fontFamily.semibold,
-      color: c.text,
+      // Sair e acao destrutiva (encerra sessao). Padrao iOS: label em
+      // tom de erro, border neutra (nao alarmante demais).
+      color: c.error,
     },
     pressedSoft: { opacity: 0.7 },
   });

--- a/app/lead/[id].tsx
+++ b/app/lead/[id].tsx
@@ -149,7 +149,7 @@ export default function LeadDetailScreen() {
     return (
       <View style={styles.container}>
         {BackPill}
-        <View style={[styles.scroll, { paddingTop: insets.top + spacing["4xl"] }]}>
+        <View style={[styles.scroll, { paddingTop: insets.top + spacing["3xl"] }]}>
           <Skeleton width={120} height={14} borderRadius={radius.sm} />
           <Skeleton width={240} height={32} borderRadius={radius.sm} />
           <View style={styles.skeletonRow}>
@@ -167,7 +167,7 @@ export default function LeadDetailScreen() {
     return (
       <View style={styles.container}>
         {BackPill}
-        <View style={[styles.errorWrap, { paddingTop: insets.top + spacing["4xl"] }]}>
+        <View style={[styles.errorWrap, { paddingTop: insets.top + spacing["3xl"] }]}>
           <ErrorBanner message={error} onRetry={() => void load()} />
         </View>
       </View>
@@ -196,7 +196,7 @@ export default function LeadDetailScreen() {
         contentContainerStyle={[
           styles.scroll,
           {
-            paddingTop: insets.top + spacing["4xl"],
+            paddingTop: insets.top + spacing["3xl"],
             paddingBottom: insets.bottom + footerHeight + spacing.lg,
           },
         ]}
@@ -207,6 +207,10 @@ export default function LeadDetailScreen() {
           {lead.vin ?? "—"}
         </Text>
 
+        {/* Priority como badge filled (urgencia comunica visualmente);
+            status como dot+label (mesma convencao do LeadCard) — antes
+            os dois eram badges identicos e o leitor nao sabia o que era
+            o que. */}
         <View style={styles.badgesRow}>
           <View
             style={[styles.badge, { backgroundColor: priority.bg, borderColor: priority.border }]}
@@ -215,12 +219,9 @@ export default function LeadDetailScreen() {
               {t(priority.labelKey)}
             </Text>
           </View>
-          <View
-            style={[styles.badge, { backgroundColor: status.bg, borderColor: status.border }]}
-          >
-            <Text style={[styles.badgeLabel, { color: status.color }]}>
-              {t(status.labelKey)}
-            </Text>
+          <View style={styles.statusGroup}>
+            <View style={[styles.statusDot, { backgroundColor: status.color }]} />
+            <Text style={styles.statusLabel}>{t(status.labelKey)}</Text>
           </View>
         </View>
 
@@ -302,7 +303,7 @@ function createStyles(c: ThemeColors) {
     container: { flex: 1, backgroundColor: "transparent" },
     scroll: {
       paddingHorizontal: spacing["2xl"],
-      gap: spacing.md,
+      gap: spacing.sm,
     },
     backPillFloat: {
       position: "absolute",
@@ -338,7 +339,8 @@ function createStyles(c: ThemeColors) {
     },
     badgesRow: {
       flexDirection: "row",
-      gap: spacing.sm,
+      alignItems: "center",
+      gap: spacing.md,
     },
     badge: {
       paddingHorizontal: spacing.md,
@@ -350,6 +352,21 @@ function createStyles(c: ThemeColors) {
       ...typography.label,
       textTransform: "uppercase",
       letterSpacing: 0.6,
+    },
+    statusGroup: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: spacing.xs + 2,
+    },
+    statusDot: {
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+    },
+    statusLabel: {
+      ...typography.caption,
+      color: c.textMuted,
+      fontWeight: "600",
     },
     metaLine: {
       ...typography.caption,

--- a/components/ui/MeshBackground.tsx
+++ b/components/ui/MeshBackground.tsx
@@ -25,10 +25,14 @@ const MESH: Record<"light" | "dark", MeshConfig> = {
     bottom: ["rgba(30, 30, 35, 0)", "rgba(22, 22, 22, 0.45)"],
   },
   light: {
-    base: "#F0F0F2",
-    topLeft: ["rgba(220, 220, 235, 0.50)", "rgba(220, 220, 235, 0)"],
-    topRight: ["rgba(245, 240, 235, 0.35)", "rgba(245, 240, 235, 0)"],
-    bottom: ["rgba(240, 240, 242, 0)", "rgba(240, 240, 242, 0.40)"],
+    // Antes: gradientes quase no mesmo tom da base (#F0F0F2 + 220,220,235)
+    // ficavam ~6 unidades de diferenca — invisivel ao olho. Agora: azul
+    // Ford-soft no topo-esquerdo, warm cream no topo-direito, vinheta
+    // cinza no rodape. Opacities maiores pra render real.
+    base: "#F4F5F8",
+    topLeft: ["rgba(176, 198, 230, 0.55)", "rgba(176, 198, 230, 0)"],
+    topRight: ["rgba(246, 224, 200, 0.45)", "rgba(246, 224, 200, 0)"],
+    bottom: ["rgba(210, 212, 220, 0)", "rgba(198, 200, 210, 0.55)"],
   },
 };
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,7 +30,7 @@
     "greeting_afternoon": "Good afternoon, {{name}}",
     "greeting_evening": "Good evening, {{name}}",
     "today": "Today",
-    "todays_leads": "Today's leads",
+    "recent_leads": "Recent leads",
     "empty": "No leads at the moment",
     "empty_title": "No leads yet",
     "empty_description": "When new leads are assigned to you, they will show up here.",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -34,7 +34,7 @@
     "greeting_afternoon": "Boa tarde, {{name}}",
     "greeting_evening": "Boa noite, {{name}}",
     "today": "Hoje",
-    "todays_leads": "Leads de hoje",
+    "recent_leads": "Leads recentes",
     "empty": "Nenhum lead no momento",
     "empty_title": "Sem leads por enquanto",
     "empty_description": "Quando novos leads forem atribuídos a você, eles aparecem aqui.",

--- a/lib/relative-time.ts
+++ b/lib/relative-time.ts
@@ -53,9 +53,13 @@ export function formatRelativeTime(
       : t("time.days_ago_plural", { count });
   }
 
-  // Older than a week — short date "DD/MM"
+  // Older than a week — short date. Mostra ano so quando difere do corrente
+  // pra evitar ambiguidade entre datas do ano atual e anteriores.
   const d = new Date(target);
   const dd = String(d.getDate()).padStart(2, "0");
   const mm = String(d.getMonth() + 1).padStart(2, "0");
-  return `${dd}/${mm}`;
+  const targetYear = d.getFullYear();
+  const nowYear = new Date(now).getFullYear();
+  if (targetYear === nowYear) return `${dd}/${mm}`;
+  return `${dd}/${mm}/${String(targetYear).slice(-2)}`;
 }


### PR DESCRIPTION
## Resumo

7 P2s do [QA round 2](https://github.com/fwd-ford/forward-mobile/blob/main/docs/superpowers/UX_QA_REPORT.md) atacados juntos por serem todos cosméticos, isolados e sem dependência entre si.

| ID | Issue | Onde | Fix |
| --- | --- | --- | --- |
| P2-1 | Mesh gradient invisível em light | `components/ui/MeshBackground.tsx` | Cores +saturadas (azul Ford-soft, warm cream, vinheta) e opacities 0.45–0.55 |
| P2-2 | "Idioma" duplicado (header + row) | `app/(tabs)/profile.tsx` | Row passa a mostrar o idioma SELECIONADO como label; value vira short code |
| P2-5 | Datas absolutas sem ano | `lib/relative-time.ts` | Anexar ano de 2 dígitos quando difere do corrente |
| P2-6 | Botão "Sair" sem cor destrutiva | `app/(tabs)/profile.tsx` | `signOutLabel.color = c.error` (border neutra mantida) |
| P2-7 | Lead Detail com espaço vazio demais | `app/lead/[id].tsx` | `paddingTop` 4xl→3xl, `gap` md→sm |
| P2-8 | Label "Leads de hoje" enganoso | `i18n/*.json` + `app/(tabs)/index.tsx` | Rename `home.todays_leads` → `home.recent_leads` (cards são top 5, não filtro por data) |
| P2-9 | Lead Detail: priority+status idênticos | `app/lead/[id].tsx` | Priority continua badge filled; status vira dot+label (mesma convenção do `LeadCard`) |

## Notas

- **P2-1** dark mode mantido — já funcionava. Só light recebia cores fora do range visível.
- **P2-5** padrão do iOS Mail/Slack: "15/04" mesmo ano, "15/04/25" outros anos. Pequeno overhead (2 chars) mas resolve a ambiguidade.
- **P2-8** com o seed mais realista do Ruan, datas misturadas começariam a contradizer o label "de hoje". Renomeação canônica em vez de truque visual.
- **P2-9** o helper `statusGroup`/`statusDot`/`statusLabel` em `lead/[id].tsx` é local (não justifica extrair pra UI primitive ainda — só 1 uso fora do `LeadCard`, e o `LeadCard` já tem seu próprio).

## Verificação

- [x] `npx tsc --noEmit`: pass
- [ ] Visual web (`npm run web` em :8081): mesh light visível, Profile sem dup de "Idioma", "Sair" vermelho, Lead Detail compacto e com status dot, Home com "Leads recentes", datas antigas com ano

## Fila depois disso

Fica pendente apenas o **visual QA real** (rodar Playwright/Expo Go) para validar as 2 PRs desta sessão (#56 + esta). Tudo do backend (Ruan) já foi entregue.