### PR TITLE
fix(home): hero pipeline sempre compact pra evitar quebra de linha

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -147,13 +147,14 @@ export default function HomeScreen() {
                 <View style={styles.heroCol}>
                   <Text style={styles.heroLabel}>{t("home.hero.pipeline")}</Text>
                   <Text style={styles.heroValue}>
-                    {/* Full BRL para valores <1M (R$ 999.999); acima usa
-                        compact (R$ 1.2M) pra nao estourar o hero. Antes era
-                        sempre compact, gerando R$ 3.6k visualmente
-                        inconsistente com o card abaixo (R$ 1.200 full). */}
-                    {formatBRL(hero.pipelineBRL, {
-                      compact: hero.pipelineBRL >= 1_000_000,
-                    })}
+                    {/* Compact sempre no hero. O hero tem 50% width e font
+                        grande — "R$ 3.600" (8 chars) ja estoura. Compact
+                        renderiza "R$ 3.6k" (7 chars) que cabe e mantem
+                        leitura rapida. formatBRL ignora compact pra valores
+                        < R$ 1.000 (fica full), entao pipelines pequenos
+                        nao viram "R$ 0.5k". Cards abaixo continuam full
+                        porque tem largura inteira. */}
+                    {formatBRL(hero.pipelineBRL, { compact: true })}
                   </Text>
                 </View>
               </View>


### PR DESCRIPTION
## Resumo

Achado **P0-NEW-1** do [QA round 3](https://github.com/fwd-ford/forward-mobile/blob/main/docs/superpowers/UX_QA_REPORT.md): valores >= R$ 1.000 no Pipeline do hero card quebram em duas linhas no viewport mobile.

**Antes:** \"R$ 3.600\" virava \"R$ 3.60\n0\"
**Agora:** \"R$ 3.6k\" — cabe numa linha, leitura instantânea

## Mudança

\`app/(tabs)/index.tsx\`: trocar \`compact: hero.pipelineBRL >= 1_000_000\` por \`compact: true\` no hero. O helper \`formatBRL\` já ignora o flag pra valores < R$ 1.000, então pipelines pequenos não viram \"R$ 0.5k\" — ficam full.

## Trade-off

O PR #53 (P1-2 round 2) tinha trocado pra threshold de 1M com a justificativa de manter consistência visual hero vs card (\"R$ 3.6k\" no hero vs \"R$ 1.200\" no card). Aceito esse trade-off: inconsistência visual é menor que um valor visivelmente quebrado.

Cards de lead continuam com BRL full (\`formatBRL(value)\` sem flag) porque têm largura inteira.

## Verificação

- [x] \`npx tsc --noEmit\`: pass
- [ ] Visual: rodar Expo web e ver Home — pipeline 0/500/3.600/12k/1.234.567 deve sempre caber numa linha

## Contexto

Descoberto após mergear PRs #56 + #58 nesta sessão. Round 1+2+3 de QA completo está consolidado em [project_forward_mobile_qa_round3](https://github.com/fwd-ford/forward-mobile).