### PR TITLE
security(mobile): maxLength em inputs + doc postura XSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,41 @@ Três rodadas de QA foram executadas com Playwright (web target), pegando 6 P0 +
 
 - [`docs/superpowers/UX_QA_REPORT.md`](docs/superpowers/UX_QA_REPORT.md) — round 1 (pré-fixes)
 
+### 7.6 Postura de segurança no client (XSS e validação de entrada)
+
+Resumo da análise de superfície XSS no mobile, complementar à disciplina de Cybersecurity (que cobra "Segurança de Entrada e Validação de Dados" — 20 pts).
+
+**O app não é estruturalmente vulnerável a XSS porque:**
+
+| Vetor clássico de XSS | Como o app trata |
+|-----------------------|------------------|
+| Prop `dangerouslySet`-`InnerHTML` (React) | **Não usado** em nenhum arquivo do repo (validado via grep) |
+| Manipulação direta de `innerHTML` / `outerHTML` | **Não usados** |
+| `WebView` carregando HTML externo | **Sem dependência** (`react-native-webview` não está no `package.json`) |
+| Render de HTML cru / markdown não sanitizado | **Sem dependência** (sem `react-native-render-html`, sem libs de markdown) |
+| Strings de usuário em `<Text>` JSX | **Auto-escape do React** — `{value}` nunca é interpretado como HTML |
+| Atributos `href` / `src` com input do user | App não monta URLs com input livre; `tel:` recebe número validado do `customer.phone` (backend), não do usuário |
+
+**Defesa em profundidade (validação de entrada):**
+
+- **Email no login** ([`lib/validation.ts:17`](lib/validation.ts#L17)): regex `^[^\s@]+@[^\s@]+\.[^\s@]+$` rejeita payloads tipo `<script>@evil.com` (espaço / `<` quebram o formato).
+- **Limite de tamanho (`maxLength`)** em todos os `TextInput`:
+  - Email: 254 chars (RFC 5321)
+  - Senha: 128 chars (cobre passphrase longa; Supabase trunca em 72 internamente)
+  - Busca em Leads: 80 chars (VIN tem 17, motivo curto cabe)
+- **Trim antes de enviar pro backend** ([`app/login.tsx:99`](app/login.tsx#L99)): `email.trim()` impede whitespace exploit em providers permissivos.
+- **Storage de credenciais sensíveis em `expo-secure-store`** (Keychain iOS / Keystore Android), não em AsyncStorage.
+
+**Limites assumidos (fora do escopo do client):**
+
+- Validação anti-SQLi / sanitização de strings persistidas é responsabilidade do **`forward-api-java`** (Spring Data JPA já parametriza queries por padrão).
+- Stored XSS via dados retornados pela API ainda assim seria mitigado pelo auto-escape do React no client.
+
+**Próximos passos sugeridos** (Sprint 2):
+
+- Adicionar **rate limiting** no login client-side (delay exponencial após 3 falhas) — complementa proteção de credential stuffing já existente no Supabase.
+- Adicionar **Content Security Policy** explícita no `app.config.js` quando o target web for produção.
+
 ---
 
 ## Licença

--- a/app/(tabs)/leads.tsx
+++ b/app/(tabs)/leads.tsx
@@ -188,6 +188,9 @@ export default function LeadsScreen() {
                   placeholderTextColor={colors.textSubtle}
                   autoCapitalize="none"
                   autoCorrect={false}
+                  // VIN tem 17 chars; motivo curto cabe folgado em 80.
+                  // Cap previne payload flooding em caso de paste acidental.
+                  maxLength={80}
                   onFocus={() => setSearchFocused(true)}
                   onBlur={() => setSearchFocused(false)}
                   style={[styles.searchInput, { color: colors.text }]}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -154,6 +154,9 @@ export default function LoginScreen() {
             autoCapitalize="none"
             autoCorrect={false}
             autoComplete="email"
+            // RFC 5321: total mailbox size cap = 254. Trunca no input pra
+            // bloquear payload flooding antes mesmo da validacao por regex.
+            maxLength={254}
             focused={emailFocused}
             onFocus={() => setEmailFocused(true)}
             onBlur={() => setEmailFocused(false)}
@@ -172,6 +175,9 @@ export default function LoginScreen() {
             secureTextEntry
             autoCapitalize="none"
             autoComplete="password"
+            // 128 cobre passphrases longas sem permitir DoS via senha gigante.
+            // Supabase corta em 72 (bcrypt) — limitar antes evita request grande.
+            maxLength={128}
             focused={passwordFocused}
             onFocus={() => setPasswordFocused(true)}
             onBlur={() => setPasswordFocused(false)}
@@ -248,6 +254,7 @@ type UnderlineInputProps = {
   autoCapitalize?: "none" | "sentences";
   autoCorrect?: boolean;
   autoComplete?: "email" | "password";
+  maxLength?: number;
 };
 
 function UnderlineInput({
@@ -265,6 +272,7 @@ function UnderlineInput({
   autoCapitalize,
   autoCorrect,
   autoComplete,
+  maxLength,
 }: UnderlineInputProps) {
   const lineColor = error ? colors.error : focused ? colors.text : colors.border;
   return (
@@ -280,6 +288,7 @@ function UnderlineInput({
         autoCapitalize={autoCapitalize}
         autoCorrect={autoCorrect}
         autoComplete={autoComplete}
+        maxLength={maxLength}
         onFocus={onFocus}
         onBlur={onBlur}
         style={[


### PR DESCRIPTION
## Sumário

Defesa em profundidade pra disciplina de **Cybersecurity** (critério "Limitação de tamanho e formato de entrada — Prevenir ataques de payload flooding").

## Mudanças

**`maxLength` nos 3 TextInput do app:**
- Email no login: **254 chars** (RFC 5321)
- Senha no login: **128 chars**
- Busca em Leads: **80 chars** (VIN tem 17, motivo curto cabe)

**README seção 7.6 — "Postura de segurança no client":**
- Tabela documentando que o app não usa vetor clássico de XSS (sem dangerouslySetInnerHTML, sem innerHTML, sem WebView, sem render HTML/markdown cru)
- Defesa em profundidade (regex email, maxLength, trim, expo-secure-store)
- Limites assumidos (anti-SQLi fica com o backend Java via Spring Data JPA)
- Próximos passos (rate limit client + CSP no web target)

## Test plan

- [ ] Verificar que login não aceita mais de 254 chars no email
- [ ] Verificar busca em /leads cortada em 80 chars
- [ ] Conferir renderização da seção 7.6 no GitHub